### PR TITLE
Fix issue #2: missing buildtool_depend

### DIFF
--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -4,8 +4,10 @@
   <description>The motoman stack constains libraries, configuration files, and ROS nodes for controlling a Motoman robot from ROS-Industrial</description>
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/industrial_core</url>
+  <url type="website">http://ros.org/wiki/motoman</url>
   <author email="sedwards@swri.org">Shaun Edwards</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>dx100</run_depend>
   <run_depend>fs100</run_depend>


### PR DESCRIPTION
Fix missing 'buildtool_depend' in metapackage xml.

Fix #2.

Also fixed incorrect 'website' url (pointed to wiki page for industrial_core package).
