### PR TITLE
Fix issue #19: hard coded python path in move_to_joint script

### DIFF
--- a/motoman_driver/src/move_to_joint.py
+++ b/motoman_driver/src/move_to_joint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys, yaml
 import roslib; roslib.load_manifest('motoman_driver')


### PR DESCRIPTION
As per subject. Minor change. Perhaps we should explicitly specify `python2` in the shebang.
