### PR TITLE
Added error-return from streamer to action server.

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_streamer.h
@@ -105,6 +105,7 @@ public:
 
 protected:
 
+  void publishInvalidStart();
   void trajectoryStop();
 
   boost::thread* streaming_thread_;
@@ -114,6 +115,8 @@ protected:
   TransferState state_;
   ros::Time streaming_start_;
   int min_buffer_size_;
+  ros::Publisher error_status_pub_;
+  boost::mutex error_status_pub_mutex_;
 };
 
 } //joint_trajectory_streamer


### PR DESCRIPTION
This adds the sending of an error via RobotStatus from the joint_trajectory_streamer to the action server.  This allows the action server to respond with an error immediately when there is a problem with the trajectory message.  Previously, the action server did not hear about problems with the trajectory messages, so the error would not be discovered until the action _client_ would time out, which could be several seconds.

I'm not sure how my changes fit with your idea of how this code should look.  I'm happy to modify as you like, as long as I can get that quick feedback aboud failed trajectories.
