### PR TITLE
Fixed bug in motoman_driver: external joint state messages.

### DIFF
--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -85,7 +85,6 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
 {
   if (this->version_0_)
   {
-    ROS_ERROR("motoman driver version 0");
     std::vector<std::string> joint_names;
     if (!getJointNames("controller_joint_names", "robot_description", joint_names))
       ROS_WARN("Unable to read 'controller_joint_names' param.  Using standard 6-DOF joint names.");
@@ -95,7 +94,6 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
 
   else
   {
-    ROS_ERROR("motoman driver version not-0");
     std::map<int, RobotGroup> robot_groups;
 
     std::string value;

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -85,6 +85,7 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
 {
   if (this->version_0_)
   {
+    ROS_ERROR("motoman driver version 0");
     std::vector<std::string> joint_names;
     if (!getJointNames("controller_joint_names", "robot_description", joint_names))
       ROS_WARN("Unable to read 'controller_joint_names' param.  Using standard 6-DOF joint names.");
@@ -94,6 +95,7 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
 
   else
   {
+    ROS_ERROR("motoman driver version not-0");
     std::map<int, RobotGroup> robot_groups;
 
     std::string value;
@@ -785,7 +787,10 @@ bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajecto
 void JointTrajectoryInterface::jointStateCB(
   const sensor_msgs::JointStateConstPtr &msg)
 {
-  this->cur_joint_pos_ = *msg;
+  if(msg->name.size() > 0 && msg->name[0] == all_joint_names_[0])
+  {
+    this->cur_joint_pos_ = *msg;
+  }
 }
 
 void JointTrajectoryInterface::jointStateCB(


### PR DESCRIPTION
If you use any other joints with the same ROS master and publish their values on /joint_states (as one is supposed to do), the old version of the joint_trajectory_interface.cpp would erroneously record the whole joint_state message as the "current state" of the arm.  We added a gripper to our arm and published its joint states, and the arm thought its current state involved gripper joints.

This fix is not very elegant... a complete fix might check all the joints instead of just the first, or use a CurrentStateMonitor object, or even just a hash table of the joint names and values.
