### PR TITLE
correcting comment to match with launch files: dx100 does not use bsw…

### DIFF
--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -50,7 +50,7 @@ set(CLIENT_SRC_FILES
 
 
 #-------------------------------------------------------------
-# fs100 uses same byte-ordering as most i386-based PCs
+# dx100 uses same byte-ordering as most i386-based PCs
 
 # Simple message library
 add_library(motoman_simple_message ${MSG_SRC_FILES})


### PR DESCRIPTION
…ap, FS100 does
