### PR TITLE
Reduced joint_u limits to values measured from an MH5F.

### DIFF
--- a/motoman_mh5_support/urdf/mh5_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5_macro.xacro
@@ -137,6 +137,11 @@
 			<child link="${prefix}link_u"/>
 			<origin xyz="0 0 0.3100" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
+      <!-- Old limits: lower="-2.3736" upper="4.4506" The new limits
+           below were measured from an MH5F.  They ensure that link_r
+           won't hit link_l even when joint_r is at 45 degrees.  The
+           old limits were converted directly from the MH5 data sheet,
+           which was clearly way off. -->
 			<limit lower="-1.0122" upper="3.2218" effort="100" velocity="2.96" />
 		</joint>
 		<joint name="${prefix}joint_r" type="revolute">

--- a/motoman_mh5_support/urdf/mh5_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5_macro.xacro
@@ -137,7 +137,7 @@
 			<child link="${prefix}link_u"/>
 			<origin xyz="0 0 0.3100" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-2.3736" upper="4.4506" effort="100" velocity="2.96" />
+			<limit lower="-1.0122" upper="3.2218" effort="100" velocity="2.96" />
 		</joint>
 		<joint name="${prefix}joint_r" type="revolute">
 			<parent link="${prefix}link_u"/>


### PR DESCRIPTION
The joint limits in the MH5 URDF are based on someone converting the joint limits stated in an [mh5 brochure](http://www.motoman.com/datasheets/MH5F.pdf) from degrees to radians, but don't relate to reality at all (that I can see).  Joint_u is the elbow and can clearly rotate less than 360 degrees, but the joint angle range specified by the joint limits in the brochure is greater than 360.  The upshot is that sometimes MoveIt tries to send the joint to impossible values and the robot stops with an error.

The values here are measured by turning joint_r (the next one) to about 45 degrees (the worst-case for interference) and moving joint_u until the robot refused to go any further.

I suppose I should do a pull request to motoman for their brochure, but I don't know where their repo is. :)
