### PR TITLE
Bug fix: JointTrajectoryAction 

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -39,6 +39,7 @@
 
 #include <ros/ros.h>
 #include <actionlib/server/action_server.h>
+ #include <actionlib/client/simple_action_client.h>
 
 #include <trajectory_msgs/JointTrajectory.h>
 #include <control_msgs/FollowJointTrajectoryAction.h>
@@ -77,6 +78,8 @@ public:
 
 private:
   typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> JointTractoryActionServer;
+  typedef actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> JointTractoryActionClient;
+
 
   /**
    * \brief Internal ROS node handle
@@ -115,6 +118,8 @@ private:
   std::map<int, ros::Subscriber> sub_status_;
 
   std::map<int, JointTractoryActionServer*> act_servers_;
+
+  std::map<int, JointTractoryActionClient*> act_clients_;
   /**
    * \brief Watchdog time used to fail the action request if the robot
    * driver is not responding.
@@ -191,6 +196,8 @@ private:
    * \brief The watchdog period (seconds)
    */
   static const double WATCHD0G_PERIOD_;// = 1.0;
+
+
 
   /**
    * \brief Watch dog callback, used to detect robot driver failures

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -31,7 +31,6 @@
 
 #include <algorithm>
 #include "motoman_driver/industrial_robot_client/joint_trajectory_interface.h"
-#include "motoman_driver/industrial_robot_client/motoman_utils.h"
 #include "simple_message/joint_traj_pt.h"
 #include "industrial_utils/param_utils.h"
 #include <vector>
@@ -98,11 +97,7 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
     std::map<int, RobotGroup> robot_groups;
 
     std::string value;
-    if(!ros::param::search("topics_list", value))
-    {
-      ROS_ERROR_STREAM(industrial_robot_client::motoman_utils::TOPIC_LIST_ERROR_MSG);
-      return false;
-    }
+    ros::param::search("topics_list", value);
 
     XmlRpc::XmlRpcValue topics_list_rpc;
     ros::param::get(value, topics_list_rpc);

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_streamer.cpp
@@ -268,7 +268,7 @@ void JointTrajectoryStreamer::streamingThread()
       ROS_DEBUG("Sending joint trajectory point");
       if (this->connection_->sendAndReceiveMsg(msg, reply, false))
       {
-        ROS_INFO("Point[%d of %d] sent to controller",
+        ROS_DEBUG("Point[%d of %d] sent to controller",
                  this->current_point_, static_cast<int>(this->current_traj_.size()));
         this->current_point_++;
       }

--- a/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
@@ -30,7 +30,6 @@
  */
 
 #include "motoman_driver/industrial_robot_client/robot_state_interface.h"
-#include "motoman_driver/industrial_robot_client/motoman_utils.h"
 #include "industrial_utils/param_utils.h"
 #include <map>
 #include <string>
@@ -99,11 +98,7 @@ bool RobotStateInterface::init(SmplMsgConnection* connection)
     std::map<int, RobotGroup> robot_groups;
 
     std::string value;
-    if(!ros::param::search("topics_list", value))
-    {
-      ROS_ERROR_STREAM(industrial_robot_client::motoman_utils::TOPIC_LIST_ERROR_MSG);
-      return false;
-    }
+    ros::param::search("topics_list", value);
 
     XmlRpc::XmlRpcValue topics_list_rpc;
     ros::param::get(value, topics_list_rpc);


### PR DESCRIPTION
JointTrajectoryAction can now handle correctly cases where a single trajectory containing all robots (2 arms 2 torsos) of motoman is used.

Before this fix the state of the robot changed at "LOST" after some seconds and the trajectory was aborted.
