### PR TITLE
Update readme: add build status badge and update text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Motoman
 
-[ROS-Industrial][] motoman meta-package.  See the [ROS wiki][] page for more information.  
+[![Build Status](http://build.ros.org/job/Idev__motoman__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__motoman__ubuntu_trusty_amd64)
+
+[ROS-Industrial][] Motoman meta-package. See the [ROS wiki][] page for more information.
+
 
 ## Contents
 
-This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][]
+This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][].
 
 [ROS-Industrial]: http://www.ros.org/wiki/Industrial
 [ROS wiki]: http://ros.org/wiki/motoman

--- a/README.md
+++ b/README.md
@@ -2,13 +2,21 @@
 
 [![Build Status](http://build.ros.org/job/Idev__motoman__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__motoman__ubuntu_trusty_amd64)
 
-[ROS-Industrial][] Motoman meta-package. See the [ROS wiki][] page for more information.
+[ROS-Industrial][] Motoman metapackage. See the [ROS wiki][] page for more information.
+
+The [motoman_experimental][] repository contains additional packages.
 
 
 ## Contents
 
-This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][].
+Branch naming follows the ROS distribution they are compatible with. `-devel`
+branches may be unstable. Releases are made from the distribution branches
+(`hydro`, `indigo`).
 
-[ROS-Industrial]: http://www.ros.org/wiki/Industrial
-[ROS wiki]: http://ros.org/wiki/motoman
-[SVN repo]: https://code.google.com/p/swri-ros-pkg/source/browse
+Older releases may be found in the old ROS-Industrial [subversion repository][]
+archive.
+
+[ROS-Industrial]: http://wiki.ros.org/Industrial
+[ROS wiki]: http://wiki.ros.org/motoman
+[motoman_experimental]: https://github.com/ros-industrial/motoman_experimental
+[subversion repository]: https://github.com/ros-industrial/swri-ros-pkg


### PR DESCRIPTION
As per subject.

Mentions the `motoman_experimental` repository, and provides some minor rationale for branch names.

6c6c38b (text update) is optional. I can remove it if desired.
