### PR TITLE
Refactor all SIA support pkgs into single pkg

### DIFF
--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -43,5 +43,10 @@
  <run_depend>joint_state_publisher</run_depend>
  <export>
   <architecture_independent/>
+  <deprecated>
+    This package will be removed in ROS Kinetic. The configuration data and
+    models included in this package can now be found in the motoman_sia_support
+    package in ROS Jade.
+  </deprecated>
  </export>
 </package>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -43,5 +43,10 @@
  <run_depend>joint_state_publisher</run_depend>
  <export>
   <architecture_independent/>
+  <deprecated>
+    This package will be removed in ROS Kinetic. The configuration data and
+    models included in this package can now be found in the motoman_sia_support
+    package in ROS Jade.
+  </deprecated>
  </export>
 </package>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -43,5 +43,10 @@
  <run_depend>joint_state_publisher</run_depend>
  <export>
   <architecture_independent/>
+  <deprecated>
+    This package will be removed in ROS Kinetic. The configuration data and
+    models included in this package can now be found in the motoman_sia_support
+    package in ROS Jade.
+  </deprecated>
  </export>
 </package>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -43,5 +43,10 @@
  <run_depend>joint_state_publisher</run_depend>
  <export>
   <architecture_independent/>
+  <deprecated>
+    This package will be removed in ROS Kinetic. The configuration data and
+    models included in this package can now be found in the motoman_sia_support
+    package in ROS Jade.
+  </deprecated>
  </export>
 </package>


### PR DESCRIPTION
This is a discussion PR. I want to gather some feedback on this before putting in too much work.

Based on the observation in #65, the proposed package layout more closely follows the idea of the [support pkg conventions](http://wiki.ros.org/Industrial/Tutorials/WorkingWithRosIndustrialRobotSupportPackages) by merging all support for robots in the SIA family into a single `motoman_sia_support` package. This gets rid of the 4 pkgs that are currently used for those robots.

Besides changes to the file and directory layout, I've also removed all `f` and `d` suffixes on all files that had them: the robots themselves do not appear to be different, and the launch files required specifying a `controller` arg anyway (which resulted in the rather confusing situation where you could `roslaunch ..._sia20d.launch controller:=fs100 ..`).

The changes shown in the diff aren't too interesting, it's probably easier to look at the package contents after a PR such as this one would've been merged: [here](https://github.com/gavanderhoorn/motoman/tree/f7d3359e42d6b0624c6d3677b6c90611bf2cf212/motoman_sia_support).

Question: would it make sense to add back the `..._siaXd` and `..._siaXf` launch files? They could just wrap the already present `..._siaX` launch file as a convenience, and provide a value for the `controller` arg based on their suffix. It would mean adding additional files, but it would also remove one extra argument that has to be propagated in 'calling' launch files.
