### PR TITLE
Fix compilation with g++ 6

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -209,7 +209,7 @@ private:
    *
    */
 
-  void goalCB(JointTractoryActionServer::GoalHandle & gh);
+  void goalCB(JointTractoryActionServer::GoalHandle gh);
 
   /**
    * \brief Action server cancel callback method
@@ -218,7 +218,7 @@ private:
    *
    */
 
-  void cancelCB(JointTractoryActionServer::GoalHandle & gh);
+  void cancelCB(JointTractoryActionServer::GoalHandle gh);
   /**
    * \brief Controller state callback (executed when feedback message
    * received)
@@ -227,7 +227,7 @@ private:
    *
    */
 
-  void goalCB(JointTractoryActionServer::GoalHandle & gh, int group_number);
+  void goalCB(JointTractoryActionServer::GoalHandle gh, int group_number);
 
   /**
    * \brief Action server cancel callback method
@@ -236,7 +236,7 @@ private:
    *
    */
 
-  void cancelCB(JointTractoryActionServer::GoalHandle & gh, int group_number);
+  void cancelCB(JointTractoryActionServer::GoalHandle gh, int group_number);
   /**
    * \brief Controller state callback (executed when feedback message
    * received)

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -129,8 +129,6 @@ public:
   virtual void streamingThread();
 
 protected:
-  static const double pos_stale_time_ = 1.0;  // max time since last "current position" update, for validation (sec)
-  static const double start_pos_tol_  = 1e-4;  // max difference btwn start & current position, for validation (rad)
 
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -251,7 +251,7 @@ void JointTrajectoryAction::watchdog(const ros::TimerEvent &e, int group_number)
   trajectory_state_recvd_ = false;
 }
 
-void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
+void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
 {
   gh.setAccepted();
 
@@ -366,7 +366,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
   this->pub_trajectory_command_.publish(dyn_traj);
 }
 
-void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle & gh)
+void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle gh)
 {
   // The interface is provided, but it is recommended to use
   //  void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle & gh, int group_number)
@@ -374,7 +374,7 @@ void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle & gh)
   ROS_DEBUG("Received action cancel request");
 }
 
-void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh, int group_number)
+void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh, int group_number)
 {
   if (!gh.getGoal()->trajectory.points.empty())
   {
@@ -491,7 +491,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh, i
 }
 
 void JointTrajectoryAction::cancelCB(
-  JointTractoryActionServer::GoalHandle & gh, int group_number)
+  JointTractoryActionServer::GoalHandle gh, int group_number)
 {
   ROS_DEBUG("Received action cancel request");
   if (active_goal_map_[group_number] == gh)

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -56,6 +56,12 @@ namespace motoman
 namespace joint_trajectory_streamer
 {
 
+namespace
+{
+  const double pos_stale_time_ = 1.0;  // max time since last "current position" update, for validation (sec)
+  const double start_pos_tol_  = 1e-4;  // max difference btwn start & current position, for validation (rad)
+}
+
 #define ROS_ERROR_RETURN(rtn,...) do {ROS_ERROR(__VA_ARGS__); return(rtn);} while(0)
 
 // override init() to read "robot_id" parameter and subscribe to joint_states


### PR DESCRIPTION
Since the motoman driver seems to contain a copy of the `industrial_robot_client`, I had to do the same here as with ros-industrial/industrial_core#143. It seems weird that this copy exists, but I'm sure there are reasons.

Additionally, g++ 6 no longer accepts initialization of non-integral static const members (such as double) in class definitions. This was never legal C++ although g++ and clang++ used to accept it. It seems g++ 6 dropped support for this in favour of `constexpr` members, which are much easier for the compiler to deal with. However, `constexpr` is a C++11 feature, so instead I moved the constants to the source file where they are actually used (in an anonymous namespace to prevent possible linking problems).
