### PR TITLE
sia5d: use meshes in support pkg. Fix #81.

### DIFF
--- a/motoman_sia5d_support/urdf/sia5d.urdf
+++ b/motoman_sia5d_support/urdf/sia5d.urdf
@@ -5,17 +5,18 @@
 <!-- =================================================================================== -->
 <!--Generates a urdf from the macro in sia5_macro.xacro -->
 <robot name="motoman_sia5d" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!--degrees to radians-->
   <link name="base_link">
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/base.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/base.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/base.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/base.dae"/>
       </geometry>
     </collision>
   </link>
@@ -23,13 +24,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_s.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_s.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_s.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_s.dae"/>
       </geometry>
     </collision>
   </link>
@@ -45,13 +46,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_l.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_l.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_l.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_l.dae"/>
       </geometry>
     </collision>
   </link>
@@ -66,13 +67,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_e.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_e.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_e.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_e.dae"/>
       </geometry>
     </collision>
   </link>
@@ -87,13 +88,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_u.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_u.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_u.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_u.dae"/>
       </geometry>
     </collision>
   </link>
@@ -108,13 +109,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_r.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_r.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_r.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_r.dae"/>
       </geometry>
     </collision>
   </link>
@@ -129,13 +130,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_b.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_b.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_b.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_b.dae"/>
       </geometry>
     </collision>
   </link>
@@ -150,13 +151,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_t.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_t.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_t.dae"/>
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_t.dae"/>
       </geometry>
     </collision>
   </link>
@@ -174,3 +175,4 @@
     <child link="tool0"/>
   </joint>
 </robot>
+

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -10,13 +10,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/base.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/base.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/base.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/base.dae" />
       </geometry>
     </collision>
   </link>
@@ -25,13 +25,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_s.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_s.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_s.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_s.dae" />
       </geometry>
     </collision>
   </link>
@@ -48,13 +48,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_l.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_l.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_l.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_l.dae" />
       </geometry>
     </collision>
   </link>
@@ -71,13 +71,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_e.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_e.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_e.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_e.dae" />
       </geometry>
     </collision>
   </link>
@@ -94,13 +94,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_u.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_u.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_u.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_u.dae" />
       </geometry>
     </collision>
   </link>
@@ -117,13 +117,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_r.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_r.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_r.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_r.dae" />
       </geometry>
     </collision>
   </link>
@@ -140,13 +140,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_b.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_b.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_b.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_b.dae" />
       </geometry>
     </collision>
   </link>
@@ -163,13 +163,13 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/visual/link_t.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/visual/link_t.dae" />
       </geometry>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://motoman_config/meshes/sia5/collision/link_t.dae" />
+        <mesh filename="package://motoman_sia5d_support/meshes/sia5d/collision/link_t.dae" />
       </geometry>
     </collision>
   </link>


### PR DESCRIPTION
As per subject.

This was the last xacro (at least in `motoman` itself) that used files from `motoman_config`.
