### PR TITLE
Cast vector.size() to int to eliminate nasty compile warnings

### DIFF
--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -302,7 +302,7 @@ bool MotomanJointTrajectoryStreamer::VectorToJointData(const std::vector<double>
 {
   if (vec.size() > joints.getMaxNumJoints())
     ROS_ERROR_RETURN(false, "Failed to copy to JointData.  Len (%d) out of range (0 to %d)",
-                     vec.size(), joints.getMaxNumJoints());
+                     (int)vec.size(), joints.getMaxNumJoints());
 
   joints.init();
   for (int i = 0; i < vec.size(); ++i)

--- a/motoman_driver/src/move_to_joint.py
+++ b/motoman_driver/src/move_to_joint.py
@@ -69,7 +69,7 @@ def move_to_joint(end_pos, duration):
   traj = build_traj(get_cur_pos(), end_pos, duration)
 
   # wait for subscribers to connect
-  pub = rospy.Publisher('joint_path_command', JointTrajectory)
+  pub = rospy.Publisher('joint_path_command', JointTrajectory, queue_size=1)
   if not wait_for_subs(pub, 1, 0.5, 2.0):
     rospy.logwarn('Timeout while waiting for subscribers.  Publishing trajectory anyway.')
 


### PR DESCRIPTION
I got tired of seeing 15 lines of compiler warnings about ros logging not getting the right type, so I decided to make this tiny fix.
