### PR TITLE
Fix for issue #104: fix incorrect joint limits in SIA10 urdf/xacro

### DIFF
--- a/motoman_sia10d_support/urdf/sia10d.urdf
+++ b/motoman_sia10d_support/urdf/sia10d.urdf
@@ -228,49 +228,49 @@
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.96"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.9670"/>
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
     <child link="link_l"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="2.96"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="2.9670"/>
   </joint>
   <joint name="joint_e" type="revolute">
     <parent link="link_l"/>
     <child link="link_e"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-2.96" upper="2.96" velocity="2.96"/>
+    <limit effort="100" lower="-2.9670" upper="2.9670" velocity="2.9670"/>
   </joint>
   <joint name="joint_u" type="revolute">
     <parent link="link_e"/>
     <child link="link_u"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-2.35" upper="2.35" velocity="2.96"/>
+    <limit effort="100" lower="-2.3561" upper="2.3561" velocity="2.9670"/>
   </joint>
   <joint name="joint_r" type="revolute">
     <parent link="link_u"/>
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.360"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.4906"/>
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
     <child link="link_b"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="3.48"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="3.4906"/>
   </joint>
   <joint name="joint_t" type="revolute">
     <parent link="link_b"/>
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.155"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.9813"/>
   </joint>
   <!-- end of joint list -->
 </robot>

--- a/motoman_sia10d_support/urdf/sia10d.urdf
+++ b/motoman_sia10d_support/urdf/sia10d.urdf
@@ -4,6 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="motoman_sia10d" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- link list -->
   <link name="world">
     <origin rpy="0 0 0" xyz="0 0 0"/>
   </link>
@@ -215,6 +216,8 @@
     <selfCollide>true</selfCollide>
     <material>Gazebo/White</material>
   </gazebo>
+  <!-- end of link list -->
+  <!-- joint list -->
   <joint name="world-base" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="world"/>
@@ -225,7 +228,7 @@
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="2.96"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.96"/>
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
@@ -253,7 +256,7 @@
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.360"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
@@ -267,6 +270,8 @@
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.155"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
   </joint>
+  <!-- end of joint list -->
 </robot>
+

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -240,7 +240,7 @@
 			<child link="${prefix}link_s"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="2.96" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.96" />
 		</joint>
 		<joint name="${prefix}joint_l" type="revolute">
 			<parent link="${prefix}link_s"/>
@@ -268,7 +268,7 @@
 			<child link="${prefix}link_r"/>
 			<origin xyz="0 0 0.360" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.48" />
 		</joint>
 		<joint name="${prefix}joint_b" type="revolute">
 			<parent link="${prefix}link_r"/>
@@ -282,7 +282,7 @@
 			<child link="${prefix}link_t"/>
 			<origin xyz="0 0 0.155" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.97" />
 		</joint>
 		<!-- end of joint list -->
 	</xacro:macro>

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -240,49 +240,49 @@
 			<child link="${prefix}link_s"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.96" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_l" type="revolute">
 			<parent link="${prefix}link_s"/>
 			<child link="${prefix}link_l"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 1 0" />
-			<limit lower="-1.91" upper="1.91" effort="100" velocity="2.96" />
+			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_e" type="revolute">
 			<parent link="${prefix}link_l"/>
 			<child link="${prefix}link_e"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-2.96" upper="2.96" effort="100" velocity="2.96" />
+			<limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_u" type="revolute">
 			<parent link="${prefix}link_e"/>
 			<child link="${prefix}link_u"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-2.35" upper="2.35" effort="100" velocity="2.96" />
+			<limit lower="-2.3561" upper="2.3561" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_r" type="revolute">
 			<parent link="${prefix}link_u"/>
 			<child link="${prefix}link_r"/>
 			<origin xyz="0 0 0.360" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_b" type="revolute">
 			<parent link="${prefix}link_r"/>
 			<child link="${prefix}link_b"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-1.91" upper="1.91" effort="100" velocity="3.48" />
+			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_t" type="revolute">
 			<parent link="${prefix}link_b"/>
 			<child link="${prefix}link_t"/>
 			<origin xyz="0 0 0.155" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
 		</joint>
 		<!-- end of joint list -->
 	</xacro:macro>

--- a/motoman_sia10f_support/urdf/sia10f.urdf
+++ b/motoman_sia10f_support/urdf/sia10f.urdf
@@ -137,7 +137,7 @@
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="2.96"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.96"/>
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
@@ -165,7 +165,7 @@
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.360"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
@@ -179,6 +179,6 @@
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.155"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
   </joint>
 </robot>

--- a/motoman_sia10f_support/urdf/sia10f.urdf
+++ b/motoman_sia10f_support/urdf/sia10f.urdf
@@ -137,48 +137,48 @@
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.96"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.9670" />
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
     <child link="link_l"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="2.96"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="2.9670" />
   </joint>
   <joint name="joint_e" type="revolute">
     <parent link="link_l"/>
     <child link="link_e"/>
     <origin rpy="0 0 0" xyz="0 0 0.36"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-2.96" upper="2.96" velocity="2.96"/>
+    <limit effort="100" lower="-2.9670" upper="2.9670" velocity="2.9670" />
   </joint>
   <joint name="joint_u" type="revolute">
     <parent link="link_e"/>
     <child link="link_u"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-2.35" upper="2.35" velocity="2.96"/>
+    <limit effort="100" lower="-2.3561" upper="2.3561" velocity="2.9670" />
   </joint>
   <joint name="joint_r" type="revolute">
     <parent link="link_u"/>
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.360"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.4906" />
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
     <child link="link_b"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="3.48"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="3.4906" />
   </joint>
   <joint name="joint_t" type="revolute">
     <parent link="link_b"/>
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.155"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.9813" />
   </joint>
 </robot>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -138,7 +138,7 @@
 			<child link="${prefix}link_1_s"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1416" upper="3.1416" effort="0" velocity="2.96" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.96" />
 		</joint>
 		<joint name="${prefix}joint_2_l" type="revolute">
 			<parent link="${prefix}link_1_s"/>
@@ -166,7 +166,7 @@
 			<child link="${prefix}link_5_r"/>
 			<origin xyz="0 0 0.360" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="0" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.48" />
 		</joint>
 		<joint name="${prefix}joint_6_b" type="revolute">
 			<parent link="${prefix}link_5_r"/>
@@ -180,7 +180,7 @@
 			<child link="${prefix}link_7_t"/>
 			<origin xyz="0 0 0.155" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="0" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.97" />
 		</joint>
     <joint name="${prefix}joint_tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1416"/>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -138,49 +138,49 @@
 			<child link="${prefix}link_1_s"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.96" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_2_l" type="revolute">
 			<parent link="${prefix}link_1_s"/>
 			<child link="${prefix}link_2_l"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 1 0" />
-			<limit lower="-1.91" upper="1.91" effort="0" velocity="2.96" />
+			<limit lower="-1.9198" upper="1.9198" effort="0" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_3_e" type="revolute">
 			<parent link="${prefix}link_2_l"/>
 			<child link="${prefix}link_3_e"/>
 			<origin xyz="0 0 0.36" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-2.96" upper="2.96" effort="0" velocity="2.96" />
+			<limit lower="-2.9670" upper="2.9670" effort="0" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_4_u" type="revolute">
 			<parent link="${prefix}link_3_e"/>
 			<child link="${prefix}link_4_u"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-2.35" upper="2.35" effort="0" velocity="2.96" />
+			<limit lower="-2.3561" upper="2.3561" effort="0" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_5_r" type="revolute">
 			<parent link="${prefix}link_4_u"/>
 			<child link="${prefix}link_5_r"/>
 			<origin xyz="0 0 0.360" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_6_b" type="revolute">
 			<parent link="${prefix}link_5_r"/>
 			<child link="${prefix}link_6_b"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-1.91" upper="1.91" effort="0" velocity="3.48" />
+			<limit lower="-1.9198" upper="1.9198" effort="0" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_7_t" type="revolute">
 			<parent link="${prefix}link_6_b"/>
 			<child link="${prefix}link_7_t"/>
 			<origin xyz="0 0 0.155" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.9813" />
 		</joint>
     <joint name="${prefix}joint_tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1416"/>


### PR DESCRIPTION
As per subject.

d300760 fixes the rounding up of `pi`.

8702ebc makes all joint limits consistent with values given in [this spec sheet](http://www.motoman.co.uk/index.php?eID=tx_nawsecuredl&u=0&file=uploads/tx_catalogrobot/Flyer_Robot_SIA_Series_E_06.2015_43.pdf&t=1468483513&hash=74c7c80310b166b7ee5b5ce4bbc918d7d208a945). Degrees converted to radians and floats truncated after the fourth decimal digit.
