### PR TITLE
Fix for issue #102: fix incorrect joint limits in SIA20 urdf/xacro

### DIFF
--- a/motoman_sia20d_support/urdf/sia20d.urdf
+++ b/motoman_sia20d_support/urdf/sia20d.urdf
@@ -4,6 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="motoman_sia20d" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- link list -->
   <link name="base_link">
     <visual>
       <geometry>
@@ -135,12 +136,14 @@
     </collision>
   </link>
   <link name="tool0"/>
+  <!-- end of link list -->
+  <!-- joint list -->
   <joint name="joint_s" type="revolute">
     <parent link="base_link"/>
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.41"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="2.26"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.26"/>
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
@@ -168,7 +171,7 @@
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.420"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
@@ -182,11 +185,13 @@
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.18"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1416" upper="3.1416" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
   </joint>
   <joint name="link_t-tool0" type="fixed">
     <origin rpy="0 0 -3.1416" xyz="0 0 0.0"/>
     <parent link="link_t"/>
     <child link="tool0"/>
   </joint>
+  <!-- end of joint list -->
 </robot>
+

--- a/motoman_sia20d_support/urdf/sia20d.urdf
+++ b/motoman_sia20d_support/urdf/sia20d.urdf
@@ -143,49 +143,49 @@
     <child link="link_s"/>
     <origin rpy="0 0 0" xyz="0 0 0.41"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.26"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="2.2689"/>
   </joint>
   <joint name="joint_l" type="revolute">
     <parent link="link_s"/>
     <child link="link_l"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="2.26"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="2.2689"/>
   </joint>
   <joint name="joint_e" type="revolute">
     <parent link="link_l"/>
     <child link="link_e"/>
     <origin rpy="0 0 0" xyz="0 0 0.49"/>
     <axis xyz="0 0 1"/>
-    <limit effort="100" lower="-2.96" upper="2.96" velocity="2.96"/>
+    <limit effort="100" lower="-2.9670" upper="2.9670" velocity="2.9670"/>
   </joint>
   <joint name="joint_u" type="revolute">
     <parent link="link_e"/>
     <child link="link_u"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-2.26" upper="2.26" velocity="2.96"/>
+    <limit effort="100" lower="-2.2689" upper="2.2689" velocity="2.9670"/>
   </joint>
   <joint name="joint_r" type="revolute">
     <parent link="link_u"/>
     <child link="link_r"/>
     <origin rpy="0 0 0" xyz="0 0 0.420"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.48"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="3.4906"/>
   </joint>
   <joint name="joint_b" type="revolute">
     <parent link="link_r"/>
     <child link="link_b"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 -1 0"/>
-    <limit effort="100" lower="-1.91" upper="1.91" velocity="3.48"/>
+    <limit effort="100" lower="-1.9198" upper="1.9198" velocity="3.4906"/>
   </joint>
   <joint name="joint_t" type="revolute">
     <parent link="link_b"/>
     <child link="link_t"/>
     <origin rpy="0 0 0" xyz="0 0 0.18"/>
     <axis xyz="0 0 -1"/>
-    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.97"/>
+    <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.9813"/>
   </joint>
   <joint name="link_t-tool0" type="fixed">
     <origin rpy="0 0 -3.1416" xyz="0 0 0.0"/>

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -140,49 +140,49 @@
 			<child link="${prefix}link_s"/>
 			<origin xyz="0 0 0.41" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.26" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.2689" />
 		</joint>
 		<joint name="${prefix}joint_l" type="revolute">
 			<parent link="${prefix}link_s"/>
 			<child link="${prefix}link_l"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 1 0" />
-			<limit lower="-1.91" upper="1.91" effort="100" velocity="2.26" />
+			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.2689" />
 		</joint>
 		<joint name="${prefix}joint_e" type="revolute">
 			<parent link="${prefix}link_l"/>
 			<child link="${prefix}link_e"/>
 			<origin xyz="0 0 0.49" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-2.96" upper="2.96" effort="100" velocity="2.96" />
+			<limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_u" type="revolute">
 			<parent link="${prefix}link_e"/>
 			<child link="${prefix}link_u"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-2.26" upper="2.26" effort="100" velocity="2.96" />
+			<limit lower="-2.2689" upper="2.2689" effort="100" velocity="2.9670" />
 		</joint>
 		<joint name="${prefix}joint_r" type="revolute">
 			<parent link="${prefix}link_u"/>
 			<child link="${prefix}link_r"/>
 			<origin xyz="0 0 0.420" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_b" type="revolute">
 			<parent link="${prefix}link_r"/>
 			<child link="${prefix}link_b"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<axis xyz="0 -1 0" />
-			<limit lower="-1.91" upper="1.91" effort="100" velocity="3.48" />
+			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
 		</joint>
 		<joint name="${prefix}joint_t" type="revolute">
 			<parent link="${prefix}link_b"/>
 			<child link="${prefix}link_t"/>
 			<origin xyz="0 0 0.18" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
 		</joint>
     <joint name="${prefix}link_t-tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1416"/>

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -140,7 +140,7 @@
 			<child link="${prefix}link_s"/>
 			<origin xyz="0 0 0.41" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="2.26" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.26" />
 		</joint>
 		<joint name="${prefix}joint_l" type="revolute">
 			<parent link="${prefix}link_s"/>
@@ -168,7 +168,7 @@
 			<child link="${prefix}link_r"/>
 			<origin xyz="0 0 0.420" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="3.48" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.48" />
 		</joint>
 		<joint name="${prefix}joint_b" type="revolute">
 			<parent link="${prefix}link_r"/>
@@ -182,7 +182,7 @@
 			<child link="${prefix}link_t"/>
 			<origin xyz="0 0 0.18" rpy="0 0 0"/>
 			<axis xyz="0 0 -1" />
-			<limit lower="-3.1416" upper="3.1416" effort="100" velocity="6.97" />
+			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.97" />
 		</joint>
     <joint name="${prefix}link_t-tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1416"/>


### PR DESCRIPTION
As per subject.

93a9aba fixes the rounding up of `pi`.

7cfd872 makes all joint limits consistent with values given in [this spec sheet](http://www.motoman.co.uk/index.php?eID=tx_nawsecuredl&u=0&file=uploads/tx_catalogrobot/Flyer_Robot_SIA_Series_E_06.2015_43.pdf&t=1468483513&hash=74c7c80310b166b7ee5b5ce4bbc918d7d208a945). Degrees converted to radians and floats truncated after the fourth decimal digit.
