### PR TITLE
driver: update error message displayed when 'port' parameter is not found

### DIFF
--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -70,7 +70,7 @@ bool JointTrajectoryInterface::init(std::string default_ip, int default_port, bo
   }
   if (port <= 0)
   {
-    ROS_ERROR("No valid robot IP port found.  Please set ROS '~port' param");
+    ROS_ERROR("No valid robot TCP port found.  Please set ROS '~port' param");
     return false;
   }
 

--- a/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
@@ -70,7 +70,7 @@ bool RobotStateInterface::init(std::string default_ip, int default_port, bool ve
   }
   if (port <= 0)
   {
-    ROS_ERROR("No valid robot IP port found.  Please set ROS '~port' param");
+    ROS_ERROR("No valid robot TCP port found.  Please set ROS '~port' param");
     return false;
   }
 


### PR DESCRIPTION
As per subject.

Technically 'IP ports' don't exist, but it was a strange line anyway.

It still is. These messages could use some attention to make them more user friendly.
