### PR TITLE
Partial fix for 45: add 'base' frames to SIA series robots

### DIFF
--- a/motoman_sia10d_support/urdf/sia10d.urdf
+++ b/motoman_sia10d_support/urdf/sia10d.urdf
@@ -272,6 +272,12 @@
     <axis xyz="0 0 -1"/>
     <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.9813"/>
   </joint>
-  <!-- end of joint list -->
+
+  <link name="base"/>
+  <joint name="link_l-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="link_l"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -285,5 +285,13 @@
 			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
 		</joint>
 		<!-- end of joint list -->
+
+		<!-- ROS base_link (via link_l) to Motoman Robot (not Base) Frame transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}link_l-base" type="fixed">
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<parent link="${prefix}link_l"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/motoman_sia10f_support/urdf/sia10f.urdf
+++ b/motoman_sia10f_support/urdf/sia10f.urdf
@@ -181,4 +181,10 @@
     <axis xyz="0 0 -1"/>
     <limit effort="100" lower="-3.1415" upper="3.1415" velocity="6.9813" />
   </joint>
+  <link name="base"/>
+  <joint name="link_l-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="link_l"/>
+    <child link="base"/>
+  </joint>
 </robot>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -188,5 +188,13 @@
       <child link="${prefix}link_tool0" />
     </joint>
 		<!-- end of joint list -->
+
+		<!-- ROS base_link (via link_l) to Motoman Robot (not Base) Frame transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}link_2_l-base" type="fixed">
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<parent link="${prefix}link_2_l"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/motoman_sia20d_support/urdf/sia20d.urdf
+++ b/motoman_sia20d_support/urdf/sia20d.urdf
@@ -192,6 +192,12 @@
     <parent link="link_t"/>
     <child link="tool0"/>
   </joint>
-  <!-- end of joint list -->
+
+  <link name="base"/>
+  <joint name="link_l-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="link_l"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -190,5 +190,13 @@
       <child link="${prefix}tool0" />
     </joint>
 		<!-- end of joint list -->
+
+		<!-- ROS base_link (via link_l) to Motoman Robot (not Base) Frame transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}link_l-base" type="fixed">
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<parent link="${prefix}link_l"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/motoman_sia5d_support/urdf/sia5d.urdf
+++ b/motoman_sia5d_support/urdf/sia5d.urdf
@@ -174,5 +174,11 @@
     <parent link="link_t"/>
     <child link="tool0"/>
   </joint>
+  <link name="base"/>
+  <joint name="link_l-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="link_l"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -189,7 +189,14 @@
     <parent link="${prefix}link_t" />
     <child link="${prefix}tool0" />
   </joint>
-  
+
+    <!-- ROS base_link (via link_l) to Motoman Robot (not Base) Frame transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}link_l-base" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_l"/>
+      <child link="${prefix}base"/>
+    </joint>
 	</xacro:macro>
 </robot>
 


### PR DESCRIPTION
This adds the ROS-I standard `base` frame to all robots in the SIA series we support.

Note: I've only been able to test this on the SIA20, but according to information from Motoman, this should result in the correct `base`->`tool0` transforms (but only after #105 is fixed).
