### PR TITLE
Bug fix: JointTrajectoryAction for Dual Arm FS100

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -103,6 +103,8 @@ private:
    * robot driver).
    */
   ros::Subscriber sub_trajectory_state_;
+  
+  ros::Subscriber sub_trajectory_state_all_;
 
   std::map<int, ros::Subscriber> sub_trajectories_;
 


### PR DESCRIPTION
JointTrajectoryAction can now handle correctly cases where a single trajectory containing all robots (2 arms 2 torsos) of motoman is used. This is only vertified on Motoman SDA5F.

Before this fix the state of the robot changed at "LOST"(with error code: Transitioning goal to LOST) after some seconds and the trajectory was aborted.
This issue was discussed in [mail-lists](https://groups.google.com/forum/#!topic/swri-ros-pkg-dev/svtmTaMwqx0) and PR #79 .