### PR TITLE
Fix for #146: force CRLF line-endings for Inform Jobs

### DIFF
--- a/motoman_driver/Inform/.gitattributes
+++ b/motoman_driver/Inform/.gitattributes
@@ -2,3 +2,5 @@
 # avoids "ERROR 3200 : NOP or END instruction not found" errors when
 # loading job files onto the controller.
 *.JBI text eol=crlf
+
+*.DAT text eol=crlf

--- a/motoman_driver/Inform/.gitattributes
+++ b/motoman_driver/Inform/.gitattributes
@@ -1,0 +1,4 @@
+# Job files must have CRLF (ie: Windows) line-endings.
+# avoids "ERROR 3200 : NOP or END instruction not found" errors when
+# loading job files onto the controller.
+*.JBI text eol=crlf


### PR DESCRIPTION
This should avoid confusion such as reported in #142, by forcing git to always checkout the `*.jbi` (and `*.dat`) files with `<CR><LF>` line-endings (ie: Windows), even on platforms which normally use Unix line-endings.
