### PR TITLE
Added launch files for the DX200 and YRC1000 controllers

### DIFF
--- a/motoman_driver/launch/robot_interface_streaming_dx200.launch
+++ b/motoman_driver/launch/robot_interface_streaming_dx200.launch
@@ -1,0 +1,20 @@
+<!--
+  Contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_interface_streaming_dx200.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" default="false" />
+	<arg name="version0" default="true" />
+
+	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+
+	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="use_bswap"  value="$(arg use_bswap)" />
+		<arg name="version0"  value="$(arg version0)" />
+	</include>
+</launch>

--- a/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
+++ b/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
@@ -1,0 +1,20 @@
+<!--
+  Contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_interface_streaming_yrc1000.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" default="false" />
+	<arg name="version0" default="true" />
+
+	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+
+	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="use_bswap"  value="$(arg use_bswap)" />
+		<arg name="version0"  value="$(arg version0)" />
+	</include>
+</launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_dx200.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_dx200.launch
@@ -1,0 +1,17 @@
+<!--
+  Multigroup, contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_multigroup_interface_streaming_dx200.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" default="false" />
+
+	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+		<arg name="robot_ip"  value="$(arg robot_ip)" />
+		<arg name="use_bswap" value="$(arg use_bswap)" />
+		<arg name="version0"  value="false" />
+	</include>
+</launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_yrc1000.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_yrc1000.launch
@@ -1,0 +1,17 @@
+<!--
+  Multigroup, contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_multigroup_interface_streaming_yrc1000.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" default="false" />
+
+	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+		<arg name="robot_ip"  value="$(arg robot_ip)" />
+		<arg name="use_bswap" value="$(arg use_bswap)" />
+		<arg name="version0"  value="false" />
+	</include>
+</launch>

--- a/motoman_driver/launch/robot_state_dx200.launch
+++ b/motoman_driver/launch/robot_state_dx200.launch
@@ -1,0 +1,18 @@
+<!--
+  Contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_state_dx200.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" value="false" />
+
+	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+
+	<include file="$(find motoman_driver)/launch/robot_state.launch">
+		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="use_bswap"  value="$(arg use_bswap)" />
+	</include>
+</launch>

--- a/motoman_driver/launch/robot_state_yrc1000.launch
+++ b/motoman_driver/launch/robot_state_yrc1000.launch
@@ -1,0 +1,18 @@
+<!--
+  Contoller specific version of 'robot_interface.launch'.
+
+
+  Usage:
+    robot_state_yrc1000.launch robot_ip:=<value>
+-->
+<launch>
+	<arg name="robot_ip" />
+	<arg name="use_bswap" value="false" />
+
+	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+
+	<include file="$(find motoman_driver)/launch/robot_state.launch">
+		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="use_bswap"  value="$(arg use_bswap)" />
+	</include>
+</launch>


### PR DESCRIPTION
Added launch files for the DX200 and YRC1000 controllers to the motoman_driver folder.
Even though the DX200 and YRC1000 controllers communication are the same as the DX100 controller and that connection to those controller can be launch using the reference to "dx100" for controller, for clarity and ease of use, we add explicit launch file for the newer controllers.