### PR TITLE
Issue166 xacro naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ env:
     - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/motoman_sda10f_support/test/launch_test.xml
+++ b/motoman_sda10f_support/test/launch_test.xml
@@ -38,6 +38,11 @@
   <group ns="test_sda10f">
 	  <include file="$(find motoman_sda10f_support)/launch/test_sda10f.launch"/>
   </group>
+  
+  
+  <group ns="urdf_sda10f">
+	  <param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_sda10f_support)/test/sda10f_test.xacro'" />
+  </group>
 
 
   <group ns="robot_interface_streaming_sda10f">

--- a/motoman_sda10f_support/test/sda10f_test.xacro
+++ b/motoman_sda10f_support/test/sda10f_test.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<robot name="motoman_sda10f_test" xmlns:xacro="http://ros.org/wiki/xacro">
+	<xacro:include filename="$(find motoman_sda10f_support)/urdf/sda10f_macro.xacro" />
+	<xacro:motoman_sda10f prefix=""/>
+	<!-- xacro below should not be used, use form above-->
+	<!--xacro:sda10f/-->
+	<xacro:motoman_sda10f prefix="my_prefix_"/>
+	
+	
+	<joint name="base_link_joint" type="fixed" >
+    <origin xyz="1.0 0 0"/>
+    <parent link="torso_base_link" />
+    <child link="my_prefix_torso_base_link" />
+  </joint>
+  
+</robot>
+

--- a/motoman_sda10f_support/test/sda10f_test.xacro
+++ b/motoman_sda10f_support/test/sda10f_test.xacro
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_sda10f_test" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sda10f_support)/urdf/sda10f_macro.xacro" />
-	<xacro:motoman_sda10f prefix=""/>
-	<!-- xacro below should not be used, use form above-->
-	<!--xacro:sda10f/-->
-	<xacro:motoman_sda10f prefix="my_prefix_"/>
-	
-	
-	<joint name="base_link_joint" type="fixed" >
+  <xacro:include filename="$(find motoman_sda10f_support)/urdf/sda10f_macro.xacro" />
+  <xacro:motoman_sda10f prefix=""/>
+  <!-- xacro below should not be used, use form above-->
+  <!--xacro:sda10f/-->
+  <xacro:motoman_sda10f prefix="my_prefix_"/>
+  
+  
+  <joint name="base_link_joint" type="fixed" >
     <origin xyz="1.0 0 0"/>
     <parent link="torso_base_link" />
     <child link="my_prefix_torso_base_link" />

--- a/motoman_sda10f_support/urdf/arm_macro.xacro
+++ b/motoman_sda10f_support/urdf/arm_macro.xacro
@@ -116,7 +116,7 @@
 	    <link name="${prefix}link_tool0" />
 		
 		<joint name="${prefix}joint_1_s" type="revolute">
-			<parent link="torso_link_b1"/>
+			<parent link="${parent}"/>
 			<child link="${prefix}link_1_s"/>
 			<origin xyz="0.09996 ${reflect*0.0275} 0.32214" rpy="1.57 0 ${(reflect-1)*1.57}"/>
 			<axis xyz="0 0 ${-reflect}" />

--- a/motoman_sda10f_support/urdf/common_torso_macro.xacro
+++ b/motoman_sda10f_support/urdf/common_torso_macro.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 	<xacro:macro name="torso" params="name prefix">
 		<!-- link list -->
-		<link name="base_link">
+		<link name="${prefix}base_link">
 			<visual>
 				<geometry>
 					<mesh filename="package://motoman_sda10f_support/meshes/sda10f/visual/motoman_base.stl" />
@@ -58,14 +58,14 @@
 		</link>
 		<!-- joint list -->
 		<joint name="${prefix}joint_b1" type="revolute">
-			<parent link="base_link"/>
+			<parent link="${prefix}base_link"/>
 			<child link="${prefix}link_b1"/>
 			<origin xyz="0.09257 0 0.8835" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />
 			<limit lower="-2.9570" upper="2.9570" effort="100" velocity="2.26" />
 		</joint>
 		<joint name="${prefix}joint_b2" type="revolute">
-			<parent link="base_link"/>
+			<parent link="${prefix}base_link"/>
 			<child link="${prefix}link_b2"/>
 			<origin xyz="0.09257 0 0.8835" rpy="0 0 0"/>
 			<axis xyz="0 0 1" />

--- a/motoman_sda10f_support/urdf/sda10f_macro.xacro
+++ b/motoman_sda10f_support/urdf/sda10f_macro.xacro
@@ -1,17 +1,25 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
-    name="sda10f">	
-        <xacro:include filename="$(find motoman_sda10f_support)/urdf/common_torso_macro.xacro" />
-        <xacro:include filename="$(find motoman_sda10f_support)/urdf/arm_macro.xacro" />
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+     <xacro:include filename="$(find motoman_sda10f_support)/urdf/common_torso_macro.xacro" />
+     <xacro:include filename="$(find motoman_sda10f_support)/urdf/arm_macro.xacro" />
+     <xacro:macro name="motoman_sda10f" params="prefix">	
         
-        <xacro:torso name="torso" prefix="torso_"/>
+        <xacro:torso name="${prefix}torso" prefix="${prefix}torso_"/>
 
         
-        <xacro:motoman_arm name="arm_left" prefix="arm_left_" parent="torso_link_b1" reflect="1">
+        <xacro:motoman_arm name="${prefix}arm_left" prefix="${prefix}arm_left_" parent="${prefix}torso_link_b1" reflect="1">
             <origin xyz="0.09996 0.0275 0.32214" rpy="1.57 0 0" />
         </xacro:motoman_arm>      
         
-        <xacro:motoman_arm name="arm_right" prefix="arm_right_" parent="torso_link_b1" reflect="-1">
+        <xacro:motoman_arm name="${prefix}arm_right" prefix="${prefix}arm_right_" parent="${prefix}torso_link_b1" reflect="-1">
             <origin xyz="0.09996 -0.0275 0.32214" rpy="1.57 0 0" />
-        </xacro:motoman_arm>       
+        </xacro:motoman_arm>
+     </xacro:macro>
+            
+<!-- The following xacro is kept for backwards compatibility, it should not be used -->
+<!-- see: https://github.com/ros-industrial/motoman/issues/166 -->
+     <xacro:macro name="sda10f">
+          <xacro:motoman_sda10f prefix=""/> 
+     </xacro:macro>
+
 </robot>


### PR DESCRIPTION
Do not merge, depends on #165.  These changes address bugs in the `sda10f` xacros.  Prefixing is now correctly supported and tested :)

This could be seen as a breaking change since some frame names will not be prefixed, whereas before they weren't.  However, if you tried to add a prefix to the robot name, the xacro would fail.  