### PR TITLE
Change sign of joint_u and joint_b rotation vector (#203)

### DIFF
--- a/motoman_sia5d_support/urdf/sia5d.urdf
+++ b/motoman_sia5d_support/urdf/sia5d.urdf
@@ -102,7 +102,7 @@
     <origin rpy="0 0 0" xyz="0.085 0 0"/>
     <parent link="link_e"/>
     <child link="link_u"/>
-    <axis xyz="0 1 0"/>
+    <axis xyz="0 -1 0"/>
     <limit effort="0" lower="-1.57079637" upper="2.007128695" velocity="3.4906586"/>
   </joint>
   <link name="link_r">
@@ -144,7 +144,7 @@
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="link_r"/>
     <child link="link_b"/>
-    <axis xyz="0 1 0"/>
+    <axis xyz="0 -1 0"/>
     <limit effort="0" lower="-1.91986223" upper="1.91986223" velocity="4.01425739"/>
   </joint>
   <link name="link_t">
@@ -174,6 +174,7 @@
     <parent link="link_t"/>
     <child link="tool0"/>
   </joint>
+  <!-- ROS base_link (via link_l) to Motoman Robot (not Base) Frame transform -->
   <link name="base"/>
   <joint name="link_l-base" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -181,4 +182,3 @@
     <child link="base"/>
   </joint>
 </robot>
-

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -109,7 +109,7 @@
     <origin xyz="0.085 0 0" rpy="0 0 0" />
     <parent link="${prefix}link_e" />
     <child link="${prefix}link_u" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 -1 0" />
     <limit lower="${-90*deg}" upper="${115*deg}" effort="0"  velocity="${200*deg}" />
   </joint>
 
@@ -150,12 +150,12 @@
       </geometry>
     </collision>
   </link>
-  
+
   <joint name="${prefix}joint_b" type="revolute">
     <origin xyz="0 0 0" rpy="0 0 0" />
     <parent link="${prefix}link_r" />
     <child link="${prefix}link_b" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 -1 0" />
     <limit lower="${-110*deg}" upper="${110*deg}" effort="0" velocity="${230*deg}" />
   </joint>
 


### PR DESCRIPTION
The changes made here fix the bug described in (#203) where the simulated
behavior of the robot (SIA5F) is not the same as the physical robot.
The joints U and B rotate in the opposite direction when comparing
simulation and physical robot.