### PR TITLE
Multiple fixes for build scripts and package manifests

### DIFF
--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -1,20 +1,25 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>motoman</name>
   <version>0.3.5</version>
   <description>The motoman stack constains libraries, configuration files, and ROS nodes for controlling a Motoman robot from ROS-Industrial</description>
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman</url>
+  <url type="website">http://wiki.ros.org/motoman</url>
   <author email="sedwards@swri.org">Shaun Edwards</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <run_depend>motoman_driver</run_depend>
-  <run_depend>motoman_mh5_support</run_depend>
-  <run_depend>motoman_sia10d_support</run_depend>
-  <run_depend>motoman_sia20d_moveit_config</run_depend>
-  <run_depend>motoman_sia20d_support</run_depend>
-  <run_depend>motoman_sia5d_support</run_depend>
+
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>motoman_mh5_support</exec_depend>
+  <exec_depend>motoman_msgs</exec_depend>
+  <exec_depend>motoman_sda10f_moveit_config</exec_depend>
+  <exec_depend>motoman_sda10f_support</exec_depend>
+  <exec_depend>motoman_sia10d_support</exec_depend>
+  <exec_depend>motoman_sia10f_support</exec_depend>
+  <exec_depend>motoman_sia20d_moveit_config</exec_depend>
+  <exec_depend>motoman_sia20d_support</exec_depend>
+  <exec_depend>motoman_sia5d_support</exec_depend>
 
   <export>
     <metapackage/>

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 #######################################
 include_directories(
   include
-  ${Boost_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS})
 
 add_definitions(-DLINUXSOCKETS=1)  #use linux sockets for communication

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -1,10 +1,10 @@
-# http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(motoman_driver)
+
 # Load catkin and all dependencies required for this package
 find_package(
-  catkin REQUIRED
-  COMPONENTS
+  catkin
+  REQUIRED COMPONENTS
     actionlib
     actionlib_msgs
     control_msgs
@@ -21,13 +21,16 @@ find_package(
     trajectory_msgs
     urdf
 )
+
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 roslint_cpp()
+
 #######################################
 ## Adding directories and definitions #
 #######################################
 include_directories(include MotoPlus inform ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+
 add_definitions(-DLINUXSOCKETS=1)  #use linux sockets for communication
 add_definitions(-DROS=1)
 
@@ -55,14 +58,14 @@ catkin_package(
 
 
 set(MSG_SRC_FILES
-  src/simple_message/motoman_motion_ctrl.cpp
-  src/simple_message/motoman_motion_ctrl_message.cpp
-  src/simple_message/motoman_motion_reply.cpp
-  src/simple_message/motoman_motion_reply_message.cpp
   src/simple_message/messages/motoman_read_single_io_message.cpp
   src/simple_message/messages/motoman_read_single_io_reply_message.cpp
   src/simple_message/messages/motoman_write_single_io_message.cpp
   src/simple_message/messages/motoman_write_single_io_reply_message.cpp
+  src/simple_message/motoman_motion_ctrl.cpp
+  src/simple_message/motoman_motion_ctrl_message.cpp
+  src/simple_message/motoman_motion_reply.cpp
+  src/simple_message/motoman_motion_reply_message.cpp
   src/simple_message/motoman_read_single_io.cpp
   src/simple_message/motoman_read_single_io_reply.cpp
   src/simple_message/motoman_write_single_io.cpp
@@ -70,22 +73,23 @@ set(MSG_SRC_FILES
 )
 
 set(CLIENT_SRC_FILES
-  src/industrial_robot_client/joint_relay_handler.cpp
-  src/industrial_robot_client/joint_feedback_relay_handler.cpp
   src/industrial_robot_client/joint_feedback_ex_relay_handler.cpp
-  src/industrial_robot_client/robot_state_interface.cpp
+  src/industrial_robot_client/joint_feedback_relay_handler.cpp
+  src/industrial_robot_client/joint_relay_handler.cpp
   src/industrial_robot_client/joint_trajectory_interface.cpp
   src/industrial_robot_client/joint_trajectory_streamer.cpp
   src/industrial_robot_client/motoman_utils.cpp
+  src/industrial_robot_client/robot_state_interface.cpp
   src/simple_message/joint_feedback_ex.cpp
   src/simple_message/joint_traj_pt_full_ex.cpp
   src/simple_message/messages/joint_feedback_ex_message.cpp
-  src/simple_message/messages/joint_traj_pt_full_ex_message.cpp)
+  src/simple_message/messages/joint_traj_pt_full_ex_message.cpp
+)
+
 
 ###########
 ## Build ##
 ###########
-
 
 #-------------------------------------------------------------
 # dx100 uses same byte-ordering as most i386-based PCs
@@ -174,6 +178,8 @@ target_link_libraries(${PROJECT_NAME}_joint_trajectory_action
   industrial_robot_client
   motoman_industrial_robot_client
   ${catkin_LIBRARIES})
+
+
 add_dependencies(${PROJECT_NAME}_joint_trajectory_action ${catkin_EXPORTED_TARGETS})
 #############
 ## Install ##
@@ -181,36 +187,36 @@ add_dependencies(${PROJECT_NAME}_joint_trajectory_action ${catkin_EXPORTED_TARGE
 
 # binaries
 install(TARGETS
-    motoman_robot_state
-    motoman_motion_streaming_interface
-    motoman_robot_state_bswap
-    motoman_motion_streaming_interface_bswap
-    ${PROJECT_NAME}_joint_trajectory_action
+  ${PROJECT_NAME}_joint_trajectory_action
+  motoman_motion_streaming_interface
+  motoman_motion_streaming_interface_bswap
+  motoman_robot_state
+  motoman_robot_state_bswap
 
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 # libraries
 install(TARGETS
-    motoman_simple_message
-    motoman_industrial_robot_client
-    motoman_simple_message_bswap
-    motoman_industrial_robot_client_bswap
+  motoman_industrial_robot_client
+  motoman_industrial_robot_client_bswap
+  motoman_simple_message
+  motoman_simple_message_bswap
 
-    DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
 # headers
 install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
 # other files
-foreach(dir Inform launch MotoPlus)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY
+    Inform
+    launch
+    MotoPlus
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(PROGRAMS src/move_to_joint.py
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(
     industrial_utils
     motoman_msgs
     roscpp
-    roslint
     sensor_msgs
     simple_message
     std_msgs
@@ -23,8 +22,6 @@ find_package(
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
-
-roslint_cpp()
 
 #######################################
 ## Adding directories and definitions #
@@ -220,3 +217,13 @@ install(DIRECTORY
 
 install(PROGRAMS src/move_to_joint.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslint REQUIRED)
+  roslint_cpp()
+endif()

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -181,7 +181,6 @@ target_link_libraries(${PROJECT_NAME}_joint_trajectory_action
   ${catkin_LIBRARIES})
 
 
-add_dependencies(${PROJECT_NAME}_joint_trajectory_action ${catkin_EXPORTED_TARGETS})
 #############
 ## Install ##
 #############

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -53,10 +53,8 @@ catkin_package(
     std_srvs
     trajectory_msgs
     urdf
-  DEPENDS
   INCLUDE_DIRS
     include
-  LIBRARIES
 )
 
 

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -29,7 +29,10 @@ roslint_cpp()
 #######################################
 ## Adding directories and definitions #
 #######################################
-include_directories(include MotoPlus inform ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+include_directories(
+  include
+  ${Boost_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS})
 
 add_definitions(-DLINUXSOCKETS=1)  #use linux sockets for communication
 add_definitions(-DROS=1)

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -144,7 +144,7 @@ target_link_libraries(motoman_simple_message_bswap
 
 # Industrial client library
 add_library(motoman_industrial_robot_client_bswap ${CLIENT_SRC_FILES})
-set_target_properties(motoman_industrial_robot_client PROPERTIES COMPILE_DEFINITIONS "BYTE_SWAPPING")
+set_target_properties(motoman_industrial_robot_client_bswap PROPERTIES COMPILE_DEFINITIONS "BYTE_SWAPPING")
 target_link_libraries(motoman_industrial_robot_client_bswap
   industrial_robot_client_bswap
   industrial_utils)

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -1,46 +1,34 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>motoman_driver</name>
   <version>0.3.5</version>
-  <description>The motoman driver package includes nodes for interfacing with a motoman
-     industrial robot controllers.</description>
+  <description>
+    This package provides nodes for interfacing with Motoman industrial robot controllers.
+  </description>
+  <author>Jeremy Zoss (Southwest Research Institute)</author>
   <maintainer email="jeremy.zoss@swri.org">Jeremy Zoss (Southwest Research Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_driver</url>
-  <author email="jeremy.zoss@swri.org">Jeremy Zoss (Southwest Research Institute)</author>
+
+  <url type="website">http://wiki.ros.org/motoman_driver</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>actionlib</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>industrial_msgs</build_depend>
-  <build_depend>industrial_robot_client</build_depend>
-  <build_depend>industrial_utils</build_depend>
-  <build_depend>motoman_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>simple_message</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>urdf</build_depend>
 
-  <run_depend>actionlib</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>industrial_msgs</run_depend>
-  <run_depend>industrial_robot_client</run_depend>
-  <run_depend>industrial_utils</run_depend>
-  <run_depend>motoman_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>simple_message</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>urdf</run_depend>
-
-  <export>
-  </export>
+  <depend>actionlib</depend>
+  <depend>actionlib_msgs</depend>
+  <depend>control_msgs</depend>
+  <depend>industrial_msgs</depend>
+  <depend>industrial_robot_client</depend>
+  <depend>industrial_utils</depend>
+  <depend>motoman_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>simple_message</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>urdf</depend>
 </package>

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslint</build_depend>
+  <test_depend>roslint</test_depend>
 
   <depend>actionlib</depend>
   <depend>actionlib_msgs</depend>

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -6,6 +6,8 @@
     This package provides nodes for interfacing with Motoman industrial robot controllers.
   </description>
   <author>Jeremy Zoss (Southwest Research Institute)</author>
+  <author>Ted Miller (MotoROS) (Yaskawa Motoman)</author>
+  <author>Eric Marcil (MotoROS) (Yaskawa Motoman)</author>
   <maintainer email="jeremy.zoss@swri.org">Jeremy Zoss (Southwest Research Institute)</maintainer>
   <license>BSD</license>
 

--- a/motoman_mh5_support/CMakeLists.txt
+++ b/motoman_mh5_support/CMakeLists.txt
@@ -7,10 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_mh5_support</name>
  <version>0.3.5</version>
  <description>
@@ -32,16 +32,16 @@
  <author>Shaun Edwards</author>
  <maintainer email="shaun.edwards@gmail.com"/>
  <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_mh5_support</url>
+ <url type="website">http://wiki.ros.org/motoman_mh5_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_msgs/CMakeLists.txt
+++ b/motoman_msgs/CMakeLists.txt
@@ -1,26 +1,43 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(motoman_msgs)
 
-find_package(catkin REQUIRED COMPONENTS std_msgs trajectory_msgs industrial_msgs genmsg message_generation)
+find_package(catkin
+  REQUIRED COMPONENTS
+    industrial_msgs
+    message_generation
+    std_msgs
+    trajectory_msgs
+)
 
 add_message_files(
+  DIRECTORY
+    msg
   FILES
-  DynamicJointsGroup.msg
-  DynamicJointPoint.msg
-  DynamicJointTrajectory.msg
-  DynamicJointState.msg
-  DynamicJointTrajectoryFeedback.msg
-  )
+    DynamicJointPoint.msg
+    DynamicJointsGroup.msg
+    DynamicJointState.msg
+    DynamicJointTrajectory.msg
+    DynamicJointTrajectoryFeedback.msg
+)
 
 add_service_files(
+  DIRECTORY
+    srv
   FILES
-  CmdJointTrajectoryEx.srv
-  )
+    CmdJointTrajectoryEx.srv
+)
 
 generate_messages(
-  DEPENDENCIES trajectory_msgs std_msgs industrial_msgs
+  DEPENDENCIES
+    industrial_msgs
+    std_msgs
+    trajectory_msgs
 )
 
 catkin_package(
-    CATKIN_DEPENDS message_runtime std_msgs trajectory_msgs industrial_msgs genmsg
+    CATKIN_DEPENDS
+      industrial_msgs
+      message_runtime
+      std_msgs
+      trajectory_msgs
 )

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -1,24 +1,22 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>motoman_msgs</name>
   <version>0.3.5</version>
-  <description>set of messages to serve as support for the multi-groups driver</description>
+  <description>Set of messages to serve as support for the multi-group driver.</description>
 
   <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
 
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_msgs</url>
+  <url type="website">http://wiki.ros.org/motoman_msgs</url>
   <author>Thiago de Freitas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>industrial_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>genmsg</build_depend>
+
   <build_depend>message_generation</build_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>industrial_msgs</run_depend>
-  <run_depend>genmsg</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <build_export_depend>message_runtime</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <depend>std_msgs</depend>
+  <depend>industrial_msgs</depend>
+  <depend>trajectory_msgs</depend>
 </package>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -1,5 +1,5 @@
-<package>
-
+<?xml version="1.0"?>
+<package format="2">
   <name>motoman_sda10f_moveit_config</name>
   <version>0.3.5</version>
   <description>
@@ -14,16 +14,18 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>xacro</run_depend>
-  <build_depend>motoman_sda10f_support</build_depend>
-  <run_depend>motoman_sda10f_support</run_depend>
-
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>motoman_sda10f_support</exec_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_sda10f_support/CMakeLists.txt
+++ b/motoman_sda10f_support/CMakeLists.txt
@@ -12,7 +12,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_sda10f_support</name>
  <version>0.3.5</version>
  <description>
@@ -32,16 +32,16 @@
  <author email="tdf@ipa.fhg.de">Thiago de Freitas</author>
  <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
  <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_sda10f_support</url>
+ <url type="website">http://wiki.ros.org/motoman_sda10f_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_sia10d_support/CMakeLists.txt
+++ b/motoman_sia10d_support/CMakeLists.txt
@@ -7,10 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_sia10d_support</name>
  <version>0.3.5</version>
  <description>
@@ -32,16 +32,16 @@
  <author>Shaun Edwards</author>
  <maintainer email="shaun.edwards@gmail.com"/>
  <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_sia10d_support</url>
+ <url type="website">http://wiki.ros.org/motoman_sia10d_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
   <deprecated>

--- a/motoman_sia10f_support/CMakeLists.txt
+++ b/motoman_sia10f_support/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia10f_support)
@@ -11,7 +12,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_sia10f_support</name>
  <version>0.3.5</version>
  <description>
@@ -36,12 +36,12 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
   <deprecated>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -1,5 +1,5 @@
-<package>
-
+<?xml version="1.0"?>
+<package format="2">
   <name>motoman_sia20d_moveit_config</name>
   <version>0.3.5</version>
   <description>
@@ -14,17 +14,18 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>industrial_robot_simulator</run_depend>
-  <build_depend>motoman_sia20d_support</build_depend>
-  <run_depend>motoman_sia20d_support</run_depend>
-
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>motoman_sia20d_support</exec_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_sia20d_support/CMakeLists.txt
+++ b/motoman_sia20d_support/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia20d_support)
@@ -6,11 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
-
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_sia20d_support</name>
  <version>0.3.5</version>
  <description>
@@ -36,12 +36,12 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
   <deprecated>

--- a/motoman_sia5d_support/CMakeLists.txt
+++ b/motoman_sia5d_support/CMakeLists.txt
@@ -7,10 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -1,5 +1,5 @@
-
-<package>
+<?xml version="1.0"?>
+<package format="2">
  <name>motoman_sia5d_support</name>
  <version>0.3.5</version>
  <description>
@@ -32,16 +32,16 @@
  <author>Shaun Edwards</author>
  <maintainer email="shaun.edwards@gmail.com"/>
  <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_sia5d_support</url>
+ <url type="website">http://wiki.ros.org/motoman_sia5d_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
- <run_depend>xacro</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>xacro</exec_depend>
  <export>
   <architecture_independent/>
   <deprecated>


### PR DESCRIPTION
Connected to ros-industrial/motoman_experimental#29.

Apart from (in some cases major) cosmetic changes, there are a few changes to pkgs that could affect current users:

 - removal of `Inform` and `MotoPlus` directories from `motoman_driver`'s include path: these should not be on the include path at all, as there is nothing in them that is relevant to the ROS side of `motoman_driver`. This has a very low chance of affecting current users, as those paths were not exported by `catkin_package(..)`.
 - `roslint` has been changed to a `test_depend`: it was a `build_depend` (as that was required for package format 1), and never exported as a dependency, but still a change
 - package manifest and build script for `motoman_msgs` has been cleaned up: `genmsg` was incorrectly listed as a `build_depend` and a `run_depend`. It was also exported as a dependency. It's not needed (`message_generation` already brings it in) and also should not be exported. Users 'benefiting' from this mistake will now have to depend on `genmsg` directly.

Note: even though most/all support pkgs are marked as `deprecated`, I've updated all the manifests to format 2 and done some cleanup to their build scripts as well. I'm not sure when we'll get to actually removing these, so in the meantime I thought it'd be nicer to harmonise everything in the repository.
