### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/motoman_gp12_support/launch/load_gp12.launch
+++ b/motoman_gp12_support/launch/load_gp12.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
 </launch>

--- a/motoman_gp7_support/launch/load_gp7.launch
+++ b/motoman_gp7_support/launch/load_gp7.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
 </launch>

--- a/motoman_gp8_support/launch/load_gp8.launch
+++ b/motoman_gp8_support/launch/load_gp8.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
 </launch>

--- a/motoman_mh50_support/launch/load_mh50.launch
+++ b/motoman_mh50_support/launch/load_mh50.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
 </launch>


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic