### PR TITLE
Add missing dependency to libxmlrpc-c++

### DIFF
--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -25,6 +25,7 @@
   <depend>industrial_msgs</depend>
   <depend>industrial_robot_client</depend>
   <depend>industrial_utils</depend>
+  <depend>libxmlrpc-c++</depend>
   <depend>motoman_msgs</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
When installing the `motoman` metapackage dependencies manually and with the `--no-install-recommends` flag, `libxmlrpc-c++` doesn't get installed. This PR force the library to be installed.

Without `libxmlrpc-c++`, the build will fail somewhere here:
https://github.com/ros-industrial/motoman/blob/kinetic-devel/motoman_driver/src/industrial_robot_client/motoman_utils.cpp#L46