### PR TITLE
Make tests optional using the CATKIN_ENABLE_TESTING option

### DIFF
--- a/motoman_gp12_support/CMakeLists.txt
+++ b/motoman_gp12_support/CMakeLists.txt
@@ -7,8 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/

--- a/motoman_gp7_support/CMakeLists.txt
+++ b/motoman_gp7_support/CMakeLists.txt
@@ -7,8 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/

--- a/motoman_gp8_support/CMakeLists.txt
+++ b/motoman_gp8_support/CMakeLists.txt
@@ -7,8 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/

--- a/motoman_mh50_support/CMakeLists.txt
+++ b/motoman_mh50_support/CMakeLists.txt
@@ -7,8 +7,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-find_package(roslaunch)
-roslaunch_add_file_check(test/launch_test.xml)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
 
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/


### PR DESCRIPTION
Most of the packages already use the `CATKIN_ENABLE_TESTING` option. This PRs unifies the use of the flag to all the other packages.