### PR TITLE
Cleanup all manifests and build scripts

### DIFF
--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -13,7 +13,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>motoman_gp12_support</exec_depend>
+  <exec_depend>motoman_gp7_support</exec_depend>
+  <exec_depend>motoman_gp8_support</exec_depend>
+  <exec_depend>motoman_mh12_support</exec_depend>
+  <exec_depend>motoman_mh50_support</exec_depend>
   <exec_depend>motoman_mh5_support</exec_depend>
+  <exec_depend>motoman_motomini_support</exec_depend>
   <exec_depend>motoman_msgs</exec_depend>
   <exec_depend>motoman_sda10f_moveit_config</exec_depend>
   <exec_depend>motoman_sda10f_support</exec_depend>

--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -4,10 +4,11 @@
   <name>motoman</name>
   <version>0.3.5</version>
   <description>The motoman stack constains libraries, configuration files, and ROS nodes for controlling a Motoman robot from ROS-Industrial</description>
-  <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
+  <author>Shaun Edwards</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/motoman</url>
-  <author email="sedwards@swri.org">Shaun Edwards</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>motoman</name>
   <version>0.3.5</version>
-  <description>The motoman stack constains libraries, configuration files, and ROS nodes for controlling a Motoman robot from ROS-Industrial</description>
+  <description>ROS-Industrial support for Yaskawa Motoman manipulators (metapackage).</description>
   <author>Shaun Edwards</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>

--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman</name>
   <version>0.3.5</version>

--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -9,6 +9,8 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/motoman</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/motoman/package.xml
+++ b/motoman/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -170,8 +170,8 @@ set_target_properties(motoman_motion_streaming_interface_bswap
   PREFIX "")
 
 add_executable(${PROJECT_NAME}_joint_trajectory_action
-  src/joint_trajectory_action_node.cpp
-  src/industrial_robot_client/joint_trajectory_action.cpp)
+  src/industrial_robot_client/joint_trajectory_action.cpp
+  src/joint_trajectory_action_node.cpp)
 target_link_libraries(${PROJECT_NAME}_joint_trajectory_action
   industrial_robot_client
   motoman_industrial_robot_client

--- a/motoman_driver/launch/robot_interface_streaming.launch
+++ b/motoman_driver/launch/robot_interface_streaming.launch
@@ -1,7 +1,7 @@
 <launch>
 
 <!-- This launch file provides a socket-based connection to industrial robots
-     that implement the standard ROS Industrial simple_message protocol.
+     that implement the standard ROS-Industrial simple_message protocol.
      *** Motion control is implemented by STREAMING path data to the robot ***
          (for DOWNLOAD-based path-control, use a different launch file)
 

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -10,6 +10,8 @@
   <author>Ted Miller (MotoROS) (Yaskawa Motoman)</author>
   <author>Eric Marcil (MotoROS) (Yaskawa Motoman)</author>
   <maintainer email="jeremy.zoss@swri.org">Jeremy Zoss (Southwest Research Institute)</maintainer>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
   <url type="website">http://wiki.ros.org/motoman_driver</url>

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -3,9 +3,7 @@
 <package format="2">
   <name>motoman_driver</name>
   <version>0.3.5</version>
-  <description>
-    This package provides nodes for interfacing with Motoman industrial robot controllers.
-  </description>
+  <description>ROS-Industrial nodes for interfacing with Yaskawa Motoman robot controllers.</description>
   <author>Jeremy Zoss (Southwest Research Institute)</author>
   <author>Ted Miller (MotoROS) (Yaskawa Motoman)</author>
   <author>Eric Marcil (MotoROS) (Yaskawa Motoman)</author>

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman_driver</name>
   <version>0.3.5</version>

--- a/motoman_gp12_support/CMakeLists.txt
+++ b/motoman_gp12_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_gp12_support)
@@ -12,7 +11,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -1,4 +1,5 @@
-
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package>
  <name>motoman_gp12_support</name>
  <version>0.1.0</version>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -1,49 +1,47 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_gp12_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman gp12 (and variants).
-    </p>
-  <p>
+  <name>motoman_gp12_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman gp12 (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman gp12 manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>gp12 - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>gp12 - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       https://www.motoman.com/hubfs/Robots/GP12.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_gp12_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Eric Marcil</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_gp12_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_gp12_support</name>
- <version>0.1.0</version>
+ <version>0.3.5</version>
  <description>
   <p>
       ROS Industrial support for the Motoman gp12 (and variants).

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -30,8 +30,9 @@
       robot model and configuration you intend to use them with.
     </p>
  </description>
- <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <author>Eric Marcil</author>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_gp12_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -32,15 +32,20 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_gp12_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_gp12_support</url>
+  <url type="website">http://wiki.ros.org/motoman_gp12_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package>
+<package format="2">
  <name>motoman_gp12_support</name>
  <version>0.1.0</version>
  <description>
@@ -37,11 +37,11 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_gp12_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman gp12 (and variants).</p>
+    <p>ROS-Industrial support for the Motoman GP12 (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman gp12 manipulators.
+      for Motoman GP12 manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>gp12 - Default</li>
+      <li>GP12 - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -41,10 +41,11 @@
 
   <test_depend>roslaunch</test_depend>
 
+  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_gp7_support/CMakeLists.txt
+++ b/motoman_gp7_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_gp7_support)
@@ -12,7 +11,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -32,15 +32,20 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_gp7_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -1,49 +1,47 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_gp7_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman gp7 (and variants).
-    </p>
-  <p>
+  <name>motoman_gp7_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman gp7 (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman gp7 manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>gp7 - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>gp7 - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       https://www.motoman.com/hubfs/Robots/gp7.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_gp7_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Eric Marcil</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_gp7_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_gp7_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman gp7 (and variants).</p>
+    <p>ROS-Industrial support for the Motoman GP7 (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman gp7 manipulators.
+      for Motoman GP7 manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>gp7 - Default</li>
+      <li>GP7 - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_gp7_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package>
+<package format="2">
  <name>motoman_gp7_support</name>
  <version>0.1.0</version>
  <description>
@@ -37,11 +37,11 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_gp7_support</name>
- <version>0.1.0</version>
+ <version>0.3.5</version>
  <description>
   <p>
       ROS Industrial support for the Motoman gp7 (and variants).

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -1,4 +1,5 @@
-
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package>
  <name>motoman_gp7_support</name>
  <version>0.1.0</version>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_gp7_support</url>
+  <url type="website">http://wiki.ros.org/motoman_gp7_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -41,10 +41,11 @@
 
   <test_depend>roslaunch</test_depend>
 
+  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_gp8_support/CMakeLists.txt
+++ b/motoman_gp8_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_gp8_support)
@@ -12,7 +11,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_gp8_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package>
+<package format="2">
  <name>motoman_gp8_support</name>
  <version>0.1.0</version>
  <description>
@@ -37,11 +37,11 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -32,15 +32,20 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_gp8_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -1,49 +1,47 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_gp8_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman gp8 (and variants).
-    </p>
-  <p>
+  <name>motoman_gp8_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman gp8 (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman gp8 manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>gp8 - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>gp8 - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       https://www.motoman.com/hubfs/Robots/gp8.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_gp8_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Eric Marcil</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_gp8_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_gp8_support</name>
- <version>0.1.0</version>
+ <version>0.3.5</version>
  <description>
   <p>
       ROS Industrial support for the Motoman gp8 (and variants).

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_gp8_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman gp8 (and variants).</p>
+    <p>ROS-Industrial support for the Motoman GP8 (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman gp8 manipulators.
+      for Motoman GP8 manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>gp8 - Default</li>
+      <li>GP8 - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_gp8_support</url>
+  <url type="website">http://wiki.ros.org/motoman_gp8_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -1,4 +1,5 @@
-
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package>
  <name>motoman_gp8_support</name>
  <version>0.1.0</version>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -41,10 +41,11 @@
 
   <test_depend>roslaunch</test_depend>
 
+  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_mh12_support/CMakeLists.txt
+++ b/motoman_mh12_support/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
+
 project(motoman_mh12_support)
 
 find_package(catkin REQUIRED)
 
 catkin_package()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -5,7 +5,9 @@
   <version>0.3.5</version>
   <description>The motoman_mh12_support package</description>
 
-  <maintainer email="Jmeyer@swri.org">Jon Meyer</maintainer>
+  <author>Jon Meyer</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package>
+<package format="2">
   <name>motoman_mh12_support</name>
   <version>0.1.0</version>
   <description>The motoman_mh12_support package</description>
@@ -10,13 +10,13 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>roslaunch</build_depend>
 
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>motoman_driver</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
+  <test_depend>roslaunch</test_depend>
+
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -4,11 +4,9 @@
   <name>motoman_mh12_support</name>
   <version>0.3.5</version>
   <description>The motoman_mh12_support package</description>
-
   <author>Jon Meyer</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
-
   <license>Apache 2.0</license>
 
   <url type="website">http://wiki.ros.org/motoman_mh12_support</url>
@@ -27,5 +25,4 @@
   <export>
     <architecture_independent/>
   </export>
-
 </package>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman_mh12_support</name>
-  <version>0.1.0</version>
+  <version>0.3.5</version>
   <description>The motoman_mh12_support package</description>
 
   <maintainer email="Jmeyer@swri.org">Jon Meyer</maintainer>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -11,6 +11,10 @@
 
   <license>Apache 2.0</license>
 
+  <url type="website">http://wiki.ros.org/motoman_mh12_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <test_depend>roslaunch</test_depend>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>motoman_mh12_support</name>
   <version>0.3.5</version>
-  <description>The motoman_mh12_support package</description>
+  <description>ROS-Industrial support for the Motoman MH12 (and variants).</description>
   <author>Jon Meyer</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package>
   <name>motoman_mh12_support</name>
   <version>0.1.0</version>

--- a/motoman_mh50_support/CMakeLists.txt
+++ b/motoman_mh50_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_mh50_support)
@@ -12,7 +11,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -1,4 +1,5 @@
-
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package>
  <name>motoman_mh50_support</name>
  <version>0.1.0</version>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_mh50_support</name>
- <version>0.1.0</version>
+ <version>0.3.5</version>
  <description>
   <p>
       ROS Industrial support for the Motoman mh50 (and variants).

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -32,15 +32,20 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_mh50_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_mh50_support</url>
+  <url type="website">http://wiki.ros.org/motoman_mh50_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -1,49 +1,47 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_mh50_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman mh50 (and variants).
-    </p>
-  <p>
+  <name>motoman_mh50_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman mh50 (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman mh50 manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>mh50 - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>mh50 - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       https://www.motoman.com/hubfs/Robots/mh50.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_mh50_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Eric Marcil</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_mh50_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_mh50_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman mh50 (and variants).</p>
+    <p>ROS-Industrial support for the Motoman MH50 (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman mh50 manipulators.
+      for Motoman MH50 manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>mh50 - Default</li>
+      <li>MH50 - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Eric Marcil</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_mh50_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package>
+<package format="2">
  <name>motoman_mh50_support</name>
  <version>0.1.0</version>
  <description>
@@ -37,11 +37,11 @@
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
  <url type="repository">https://github.com/ros-industrial/motoman</url>
  <buildtool_depend>catkin</buildtool_depend>
- <build_depend>roslaunch</build_depend>
- <run_depend>motoman_driver</run_depend>
- <run_depend>robot_state_publisher</run_depend>
- <run_depend>rviz</run_depend>
- <run_depend>joint_state_publisher</run_depend>
+ <test_depend>roslaunch</test_depend>
+ <exec_depend>motoman_driver</exec_depend>
+ <exec_depend>robot_state_publisher</exec_depend>
+ <exec_depend>rviz</exec_depend>
+ <exec_depend>joint_state_publisher</exec_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -41,10 +41,11 @@
 
   <test_depend>roslaunch</test_depend>
 
+  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_mh5_support/CMakeLists.txt
+++ b/motoman_mh5_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_mh5_support)

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -1,50 +1,48 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_mh5_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman mh5 (and variants).
-    </p>
-  <p>
+  <name>motoman_mh5_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman mh5 (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman mh5 manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>mh5 - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>mh5 - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/mh5.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://wiki.ros.org/motoman_mh5_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Shaun Edwards</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/motoman_mh5_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_mh5_support</name>
  <version>0.3.5</version>

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_mh5_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman mh5 (and variants).</p>
+    <p>ROS-Industrial support for the Motoman MH5 (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman mh5 manipulators.
+      for Motoman MH5 manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>mh5 - Default</li>
+      <li>MH5 - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_mh5_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://wiki.ros.org/motoman_mh5_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_motomini_support/package.xml
+++ b/motoman_motomini_support/package.xml
@@ -31,7 +31,9 @@
     </p>
  </description>
  <author>Eric Marcil</author>
- <maintainer email="eric.marcil@motoman.com"/>
+ <maintainer email="eric.marcil@motoman.com">Eric Marcil</maintainer>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://wiki.ros.org/motoman_motomini_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_motomini_support/package.xml
+++ b/motoman_motomini_support/package.xml
@@ -1,51 +1,49 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_motomini_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman MotoMini (and variants).
-    </p>
-  <p>
+  <name>motoman_motomini_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman MotoMini (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman MotoMini manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>MotoMini - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>MotoMini - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       https://www.motoman.com/hubfs/Robots/MotoMini.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Eric Marcil</author>
- <maintainer email="eric.marcil@motoman.com">Eric Marcil</maintainer>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://wiki.ros.org/motoman_motomini_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Eric Marcil</author>
+  <maintainer email="eric.marcil@motoman.com">Eric Marcil</maintainer>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/motoman_motomini_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_motomini_support/package.xml
+++ b/motoman_motomini_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_motomini_support</name>
  <version>0.3.5</version>

--- a/motoman_motomini_support/package.xml
+++ b/motoman_motomini_support/package.xml
@@ -33,16 +33,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_motomini_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -4,6 +4,7 @@
   <name>motoman_msgs</name>
   <version>0.3.5</version>
   <description>Set of messages to serve as support for the multi-group driver.</description>
+  <author>Thiago de Freitas</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
@@ -11,7 +12,6 @@
   <url type="website">http://wiki.ros.org/motoman_msgs</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
-  <author>Thiago de Freitas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -19,7 +19,7 @@
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
 
-  <depend>std_msgs</depend>
   <depend>industrial_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>trajectory_msgs</depend>
 </package>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>motoman_msgs</name>
   <version>0.3.5</version>
-  <description>Set of messages to serve as support for the multi-group driver.</description>
+  <description>Messages for the multi-group interface of motoman_driver.</description>
   <author>Thiago de Freitas</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman_msgs</name>
   <version>0.3.5</version>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -10,6 +10,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/motoman_msgs</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
   <author>Thiago de Freitas</author>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -5,7 +5,8 @@
   <version>0.3.5</version>
   <description>Set of messages to serve as support for the multi-group driver.</description>
 
-  <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/motoman_msgs</url>

--- a/motoman_msgs/package.xml
+++ b/motoman_msgs/package.xml
@@ -4,11 +4,10 @@
   <name>motoman_msgs</name>
   <version>0.3.5</version>
   <description>Set of messages to serve as support for the multi-group driver.</description>
-
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
-
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_msgs</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -12,9 +12,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://moveit.ros.org/</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
+  <url type="website">http://wiki.ros.org/motoman_sda10f_moveit_config</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
 
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -4,7 +4,10 @@
   <name>motoman_sda10f_moveit_config</name>
   <version>0.3.5</version>
   <description>
-     An automatically generated package with all the configuration and launch files for using the motoman_sda10f with the MoveIt Motion Planning Framework
+    <p>MoveIt package for the Motoman SDA10F.</p>
+    <p>
+      An automatically generated package with all the configuration and launch files for using the Motoman SDA10F with the MoveIt Motion Planning Framework.
+    </p>
   </description>
   <author>Thiago de Freitas</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -15,6 +15,8 @@
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
 
+  <buildtool_depend>catkin</buildtool_depend>
+
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
@@ -23,8 +25,6 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>
   <exec_depend>motoman_sda10f_support</exec_depend>
-
-  <buildtool_depend>catkin</buildtool_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -6,8 +6,9 @@
   <description>
      An automatically generated package with all the configuration and launch files for using the motoman_sda10f with the MoveIt Motion Planning Framework
   </description>
-  <author email="tdf@ipa.fhg.de">Thiago de Freitas</author>
-  <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
+  <author>Thiago de Freitas</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
 
   <license>BSD</license>
 

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman_sda10f_moveit_config</name>
   <version>0.3.5</version>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -20,14 +20,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>moveit_ros_move_group</exec_depend>
-  <exec_depend>moveit_planners_ompl</exec_depend>
-  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_sda10f_support</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>industrial_robot_simulator</exec_depend>
-  <exec_depend>motoman_sda10f_support</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -9,7 +9,6 @@
   <author>Thiago de Freitas</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
-
   <license>BSD</license>
 
   <url type="website">http://wiki.ros.org/motoman_sda10f_moveit_config</url>

--- a/motoman_sda10f_support/CMakeLists.txt
+++ b/motoman_sda10f_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sda10f_support)

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -30,8 +30,9 @@
       robot model and configuration you intend to use them with.
     </p>
  </description>
- <author email="tdf@ipa.fhg.de">Thiago de Freitas</author>
- <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
+ <author>Thiago de Freitas</author>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://wiki.ros.org/motoman_sda10f_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -1,50 +1,48 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_sda10f_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman sda10f (and variants).
-    </p>
-  <p>
+  <name>motoman_sda10f_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman sda10f (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman sda10f manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>sda10f - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>sda10f - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/sda10f.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Thiago de Freitas</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://wiki.ros.org/motoman_sda10f_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
- </export>
+  </description>
+  <author>Thiago de Freitas</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/motoman_sda10f_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_sda10f_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman sda10f (and variants).</p>
+    <p>ROS-Industrial support for the Motoman SDA10F (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman sda10f manipulators.
+      for Motoman SDA10F manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>sda10f - Default</li>
+      <li>SDA10F - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_sda10f_support</name>
  <version>0.3.5</version>

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_sda10f_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/motoman_sia10d_support/CMakeLists.txt
+++ b/motoman_sia10d_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia10d_support)

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -1,55 +1,53 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_sia10d_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman sia10d (and variants).
-    </p>
-  <p>
+  <name>motoman_sia10d_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman sia10d (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman sia10d manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>sia10d - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>sia10d - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/sia10d.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://wiki.ros.org/motoman_sia10d_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
-  <deprecated>
-    This package will be removed in ROS Kinetic. The configuration data and
-    models included in this package can now be found in the motoman_sia_support
-    package in ROS Jade.
-  </deprecated>
- </export>
+  </description>
+  <author>Shaun Edwards</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/motoman_sia10d_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+    <deprecated>
+      This package will be removed in ROS Kinetic. The configuration data and
+      models included in this package can now be found in the motoman_sia_support
+      package in ROS Jade.
+    </deprecated>
+  </export>
 </package>

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_sia10d_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman sia10d (and variants).</p>
+    <p>ROS-Industrial support for the Motoman SIA10D (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman sia10d manipulators.
+      for Motoman SIA10D manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>sia10d - Default</li>
+      <li>SIA10D - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_sia10d_support</name>
  <version>0.3.5</version>

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_sia10d_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
     <deprecated>

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://wiki.ros.org/motoman_sia10d_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_sia10f_support/CMakeLists.txt
+++ b/motoman_sia10f_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia10f_support)

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_sia10f_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman sia10f (and variants).</p>
+    <p>ROS-Industrial support for the Motoman SIA10F (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman sia10f manipulators.
+      for Motoman SIA10F manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>sia10f - Default</li>
+      <li>SIA10F - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_sia10f_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
     <deprecated>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -30,8 +30,9 @@
       robot model and configuration you intend to use them with.
     </p>
  </description>
- <author email="tdf@ipa.fhg.de">Thiago de Freitas</author>
- <maintainer email="tdf@ipa.fhg.de">Thiago de Freitas</maintainer>
+ <author>Thiago de Freitas</author>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_sia10f_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_sia10f_support</url>
+  <url type="website">http://wiki.ros.org/motoman_sia10f_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_sia10f_support</name>
  <version>0.3.5</version>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -1,55 +1,53 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_sia10f_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman sia10f (and variants).
-    </p>
-  <p>
+  <name>motoman_sia10f_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman sia10f (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman sia10f manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>sia10f - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>sia10f - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/sia10f.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Thiago de Freitas</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_sia10f_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
-  <deprecated>
-    This package will be removed in ROS Kinetic. The configuration data and
-    models included in this package can now be found in the motoman_sia_support
-    package in ROS Jade.
-  </deprecated>
- </export>
+  </description>
+  <author>Thiago de Freitas</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_sia10f_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+    <deprecated>
+      This package will be removed in ROS Kinetic. The configuration data and
+      models included in this package can now be found in the motoman_sia_support
+      package in ROS Jade.
+    </deprecated>
+  </export>
 </package>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -20,14 +20,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>moveit_ros_move_group</exec_depend>
-  <exec_depend>moveit_planners_ompl</exec_depend>
-  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_sia20d_support</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>industrial_robot_simulator</exec_depend>
-  <exec_depend>motoman_sia20d_support</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>motoman_sia20d_moveit_config</name>
   <version>0.3.5</version>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -12,9 +12,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://moveit.ros.org/</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
+  <url type="website">http://wiki.ros.org/motoman_sia20d_moveit_config</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
 
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -9,7 +9,6 @@
   <author>MoveIt Setup Assistant</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
-
   <license>BSD</license>
 
   <url type="website">http://wiki.ros.org/motoman_sia20d_moveit_config</url>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -6,8 +6,9 @@
   <description>
      An automatically generated package with all the configuration and launch files for using the motoman_sia20d with the MoveIt Motion Planning Framework
   </description>
-  <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
-  <maintainer email="assistant@moveit.ros.org">MoveIt Setup Assistant</maintainer>
+  <author>MoveIt Setup Assistant</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
 
   <license>BSD</license>
 

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -4,7 +4,10 @@
   <name>motoman_sia20d_moveit_config</name>
   <version>0.3.5</version>
   <description>
-     An automatically generated package with all the configuration and launch files for using the motoman_sia20d with the MoveIt Motion Planning Framework
+    <p>MoveIt package for the Motoman SIA20D.</p>
+    <p>
+      An automatically generated package with all the configuration and launch files for using the Motoman SIA20D with the MoveIt Motion Planning Framework.
+    </p>
   </description>
   <author>MoveIt Setup Assistant</author>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -15,6 +15,8 @@
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
 
+  <buildtool_depend>catkin</buildtool_depend>
+
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
@@ -23,8 +25,6 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>
   <exec_depend>motoman_sia20d_support</exec_depend>
-
-  <buildtool_depend>catkin</buildtool_depend>
 
   <export>
     <architecture_independent/>

--- a/motoman_sia20d_support/CMakeLists.txt
+++ b/motoman_sia20d_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia20d_support)

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_sia20d_support</name>
  <version>0.3.5</version>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_sia20d_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
     <deprecated>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://ros.org/wiki/motoman_sia20d_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -1,55 +1,53 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_sia20d_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman sia20d (and variants).
-    </p>
-  <p>
+  <name>motoman_sia20d_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman sia20d (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman sia20d manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>sia20d - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>sia20d - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/sia20d.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://ros.org/wiki/motoman_sia20d_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
-  <deprecated>
-    This package will be removed in ROS Kinetic. The configuration data and
-    models included in this package can now be found in the motoman_sia_support
-    package in ROS Jade.
-  </deprecated>
- </export>
+  </description>
+  <author>Shaun Edwards</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/motoman_sia20d_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+    <deprecated>
+      This package will be removed in ROS Kinetic. The configuration data and
+      models included in this package can now be found in the motoman_sia_support
+      package in ROS Jade.
+    </deprecated>
+  </export>
 </package>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/motoman_sia20d_support</url>
+  <url type="website">http://wiki.ros.org/motoman_sia20d_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
   <buildtool_depend>catkin</buildtool_depend>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_sia20d_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman sia20d (and variants).</p>
+    <p>ROS-Industrial support for the Motoman SIA20D (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman sia20d manipulators.
+      for Motoman SIA20D manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>sia20d - Default</li>
+      <li>SIA20D - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_sia5d_support/CMakeLists.txt
+++ b/motoman_sia5d_support/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 2.8.3)
 
 project(motoman_sia5d_support)

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
  <name>motoman_sia5d_support</name>
  <version>0.3.5</version>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -1,55 +1,53 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
- <name>motoman_sia5d_support</name>
- <version>0.3.5</version>
- <description>
-  <p>
-      ROS Industrial support for the Motoman sia5d (and variants).
-    </p>
-  <p>
+  <name>motoman_sia5d_support</name>
+  <version>0.3.5</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman sia5d (and variants).</p>
+    <p>
       This package contains configuration data, 3D models and launch files
       for Motoman sia5d manipulators.
     </p>
-  <p>
-   <b>Specifications</b>
-  </p>
-  <ul>
-   <li>sia5d - Default</li>
-  </ul>
-  <p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>sia5d - Default</li>
+    </ul>
+    <p>
       Joint limits and maximum joint velocities are based on the information 
       found in the online 
       http://www.motoman.com/datasheets/sia5d.pdf
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>
-  <p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
- </description>
- <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
- <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
- <license>BSD</license>
- <url type="website">http://wiki.ros.org/motoman_sia5d_support</url>
- <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
- <url type="repository">https://github.com/ros-industrial/motoman</url>
- <buildtool_depend>catkin</buildtool_depend>
- <test_depend>roslaunch</test_depend>
- <exec_depend>joint_state_publisher</exec_depend>
- <exec_depend>motoman_driver</exec_depend>
- <exec_depend>robot_state_publisher</exec_depend>
- <exec_depend>rviz</exec_depend>
- <exec_depend>xacro</exec_depend>
- <export>
-  <architecture_independent/>
-  <deprecated>
-    This package will be removed in ROS Kinetic. The configuration data and
-    models included in this package can now be found in the motoman_sia_support
-    package in ROS Jade.
-  </deprecated>
- </export>
+  </description>
+  <author>Shaun Edwards</author>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/motoman_sia5d_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>roslaunch</test_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <export>
+    <architecture_independent/>
+    <deprecated>
+      This package will be removed in ROS Kinetic. The configuration data and
+      models included in this package can now be found in the motoman_sia_support
+      package in ROS Jade.
+    </deprecated>
+  </export>
 </package>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -31,7 +31,8 @@
     </p>
  </description>
  <author>Shaun Edwards</author>
- <maintainer email="shaun.edwards@gmail.com"/>
+ <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+ <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
  <license>BSD</license>
  <url type="website">http://wiki.ros.org/motoman_sia5d_support</url>
  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -4,16 +4,16 @@
   <name>motoman_sia5d_support</name>
   <version>0.3.5</version>
   <description>
-    <p>ROS-Industrial support for the Motoman sia5d (and variants).</p>
+    <p>ROS-Industrial support for the Motoman SIA5D (and variants).</p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for Motoman sia5d manipulators.
+      for Motoman SIA5D manipulators.
     </p>
     <p>
       <b>Specifications</b>
     </p>
     <ul>
-      <li>sia5d - Default</li>
+      <li>SIA5D - Default</li>
     </ul>
     <p>
       Joint limits and maximum joint velocities are based on the information 

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -32,16 +32,21 @@
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/motoman_sia5d_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
   <url type="repository">https://github.com/ros-industrial/motoman</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <test_depend>roslaunch</test_depend>
+
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
+
   <export>
     <architecture_independent/>
     <deprecated>


### PR DESCRIPTION
As per subject.

Main changes:

 - upgrade all manifests to format 2 where needed (ros-industrial/ros_industrial_issues#56)
 - sort out authors and maintainers
 - harmonise manifest contents
 - sort out version numbers
 - fix missing dependencies

No functional changes to any packages.

`catkin_lint -W2` warnings / errors left after this: 3 (mostly in `motoman_driver`).
