### PR TITLE
Restore and Fix multi-group trajectory execution for multi-group robots

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -129,7 +129,11 @@ private:
   bool has_active_goal_;
 
   std::map<int, bool> has_active_goal_map_;
-
+  /**
+   * \brief Indicates which groups are active on `multi-group` action goals, 
+   * Note: independant of `has_active_goal_map_` which handles single group goals.
+   */
+  std::map<int, bool> multi_group_active_goals_map_;  
   /**
    * \brief Cache of the current active goal
    */

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -274,9 +274,12 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
       }
 
       // Generating message for groups that were not present in the trajectory message
+      // Assume that joints from these groups will mantain its current position.
+      // Velocity, acceleration and effort are zero out. 
       else
       {
-        std::vector<double> positions(num_joints, 0.0);
+        ROS_DEBUG("Group %s not present in trajectory plan, using its last received joint positions as goal", robot_groups_[group_number].get_name().c_str());
+        std::vector<double> positions = last_trajectory_state_map_[group_number]->actual.positions;
         std::vector<double> velocities(num_joints, 0.0);
         std::vector<double> accelerations(num_joints, 0.0);
         std::vector<double> effort(num_joints, 0.0);


### PR DESCRIPTION
The [first commit](https://github.com/ros-industrial/motoman/pull/259/commits/72cd3af7920fca0818375237fc375f7bab809445) addresses issue #251 which pointed out that `multi-group` trajectory execution was not working.

With this commit, the default behavior of the Motoman driver when processing a `multi-group` trajectory with missing robot groups (i.g. When moving two arms but not the torso of the robot, or when moving only the torso and one of the arms) is changed:
- **FROM:** Zeroing out the trajectory positions for the motion groups for which MoveIt! did not generate trajectory points (move groups that remain stationary on motion planning).
- **TO:** Use the most recent feedback joint values from these groups, provided by the robot controller.

A simple example to illustrate this issue is to operate both arms of a dual arm robot when the torso joint is not in home position (i.e. joint value != 0). Previously the `joint_trajectory_action` was creating the dual arm trajectory with the torso joint trajectory value set always to 0, since MoveIt! does not send any data this joint. When MotoROS receives this trajectory and tries to execute it it realizes that the initial state of the motion plan differs from the current robot state, since the torso joint is not at 0, and rejects motion execution command.