### PR TITLE
Fixes ros-industrial/motoman#260: fix warnings with -Wall

### DIFF
--- a/motoman_driver/src/industrial_robot_client/joint_feedback_ex_relay_handler.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_feedback_ex_relay_handler.cpp
@@ -89,7 +89,7 @@ bool JointFeedbackExRelayHandler::create_messages(SimpleMessage& msg_in,
   tmp_msg.init(msg_in);
   motoman_msgs::DynamicJointTrajectoryFeedback dynamic_control_state;
 
-  for (int i = 0; i < tmp_msg.getJointMessages().size(); i++)
+  for (size_t i = 0; i < tmp_msg.getJointMessages().size(); i++)
   {
     int group_number = tmp_msg.getJointMessages()[i].getRobotID();
 

--- a/motoman_driver/src/industrial_robot_client/joint_feedback_ex_relay_handler.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_feedback_ex_relay_handler.cpp
@@ -93,7 +93,10 @@ bool JointFeedbackExRelayHandler::create_messages(SimpleMessage& msg_in,
   {
     int group_number = tmp_msg.getJointMessages()[i].getRobotID();
 
-    create_messages(tmp_msg.getJointMessages()[i], control_state, sensor_state, group_number);
+    if (!create_messages(tmp_msg.getJointMessages()[i], control_state, sensor_state, group_number))
+    {
+      return false;
+    }
     motoman_msgs::DynamicJointState dyn_joint_state;
     dyn_joint_state.num_joints = control_state->joint_names.size();
     dyn_joint_state.group_number = group_number;
@@ -106,6 +109,8 @@ bool JointFeedbackExRelayHandler::create_messages(SimpleMessage& msg_in,
   dynamic_control_state.header.stamp = ros::Time::now();
   dynamic_control_state.num_groups = tmp_msg.getGroupsNumber();
   this->dynamic_pub_joint_control_state_.publish(dynamic_control_state);
+
+  return true;
 }
 
 bool JointFeedbackExRelayHandler::create_messages(JointFeedbackMessage& msg_in,

--- a/motoman_driver/src/industrial_robot_client/joint_feedback_relay_handler.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_feedback_relay_handler.cpp
@@ -284,7 +284,7 @@ bool JointFeedbackRelayHandler::select(const DynamicJointsGroup& all_joint_state
   pub_joint_names->clear();
 
   // skip over "blank" joint names
-  for (int i = 0; i < all_joint_names.size(); ++i)
+  for (size_t i = 0; i < all_joint_names.size(); ++i)
   {
     if (all_joint_names[i].empty())
       continue;

--- a/motoman_driver/src/industrial_robot_client/joint_relay_handler.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_relay_handler.cpp
@@ -295,7 +295,7 @@ bool JointRelayHandler::select(const JointTrajectoryPoint& all_joint_state, cons
   pub_joint_names->clear();
 
   // skip over "blank" joint names
-  for (int i = 0; i < all_joint_names.size(); ++i)
+  for (size_t i = 0; i < all_joint_names.size(); ++i)
   {
     if (all_joint_names[i].empty())
       continue;
@@ -323,7 +323,7 @@ bool JointRelayHandler::select(const DynamicJointsGroup& all_joint_state, const 
   pub_joint_names->clear();
 
   // skip over "blank" joint names
-  for (int i = 0; i < all_joint_names.size(); ++i)
+  for (size_t i = 0; i < all_joint_names.size(); ++i)
   {
     if (all_joint_names[i].empty())
       continue;

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -62,7 +62,7 @@ JointTrajectoryAction::JointTrajectoryAction() :
   std::map<int, RobotGroup> robot_groups;
   getJointGroups("topic_list", robot_groups);
 
-  for (int i = 0; i < robot_groups.size(); i++)
+  for (size_t i = 0; i < robot_groups.size(); i++)
   {
 
     std::string joint_path_action_name = robot_groups[i].get_ns() + "/" + robot_groups[i].get_name();
@@ -201,11 +201,11 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
 
   motoman_msgs::DynamicJointTrajectory dyn_traj;
 
-  for (int i = 0; i < gh.getGoal()->trajectory.points.size(); i++)
+  for (size_t i = 0; i < gh.getGoal()->trajectory.points.size(); i++)
   {
     motoman_msgs::DynamicJointPoint dpoint;
 
-    for (int rbt_idx = 0; rbt_idx < robot_groups_.size(); rbt_idx++)
+    for (size_t rbt_idx = 0; rbt_idx < robot_groups_.size(); rbt_idx++)
     {
       size_t ros_idx = std::find(
                          gh.getGoal()->trajectory.joint_names.begin(),
@@ -349,7 +349,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh, int
 
         motoman_msgs::DynamicJointTrajectory dyn_traj;
 
-        for (int i = 0; i < current_traj_map_[group_number].points.size(); ++i)
+        for (size_t i = 0; i < current_traj_map_[group_number].points.size(); ++i)
         {
           motoman_msgs::DynamicJointsGroup dyn_group;
           motoman_msgs::DynamicJointPoint dyn_point;

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -669,7 +669,7 @@ bool JointTrajectoryInterface::is_valid(const trajectory_msgs::JointTrajectory &
 
     // check for non-empty positions
     if (pt.positions.empty())
-      ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %d", i);
+      ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %lu", i);
 
     // check for joint velocity limits
     for (size_t j = 0; j < pt.velocities.size(); ++j)
@@ -678,12 +678,12 @@ bool JointTrajectoryInterface::is_valid(const trajectory_msgs::JointTrajectory &
       if (max_vel == joint_vel_limits_.end()) continue;  // no velocity-checking if limit not defined
 
       if (std::abs(pt.velocities[j]) > max_vel->second)
-        ROS_ERROR_RETURN(false, "Validation failed: Max velocity exceeded for trajectory pt %d, joint '%s'", i, traj.joint_names[j].c_str());
+        ROS_ERROR_RETURN(false, "Validation failed: Max velocity exceeded for trajectory pt %lu, joint '%s'", i, traj.joint_names[j].c_str());
     }
 
     // check for valid timestamp
     if ((i > 0) && (pt.time_from_start.toSec() == 0))
-      ROS_ERROR_RETURN(false, "Validation failed: Missing valid timestamp data for trajectory pt %d", i);
+      ROS_ERROR_RETURN(false, "Validation failed: Missing valid timestamp data for trajectory pt %lu", i);
   }
 
   return true;
@@ -699,7 +699,7 @@ bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajecto
 
       // check for non-empty positions
       if (pt.positions.empty())
-        ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %d", i);
+        ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %lu", i);
       // check for joint velocity limits
       for (size_t j = 0; j < pt.velocities.size(); ++j)
       {
@@ -707,12 +707,12 @@ bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajecto
         if (max_vel == joint_vel_limits_.end()) continue;  // no velocity-checking if limit not defined
 
         if (std::abs(pt.velocities[j]) > max_vel->second)
-          ROS_ERROR_RETURN(false, "Validation failed: Max velocity exceeded for trajectory pt %d, joint '%s'", i, traj.joint_names[j].c_str());
+          ROS_ERROR_RETURN(false, "Validation failed: Max velocity exceeded for trajectory pt %lu, joint '%s'", i, traj.joint_names[j].c_str());
       }
 
       // check for valid timestamp
       if ((i > 0) && (pt.time_from_start.toSec() == 0))
-        ROS_ERROR_RETURN(false, "Validation failed: Missing valid timestamp data for trajectory pt %d", i);
+        ROS_ERROR_RETURN(false, "Validation failed: Missing valid timestamp data for trajectory pt %lu", i);
     }
   }
   return true;

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -663,7 +663,7 @@ bool JointTrajectoryInterface::stopMotionCB(
 
 bool JointTrajectoryInterface::is_valid(const trajectory_msgs::JointTrajectory &traj)
 {
-  for (int i = 0; i < traj.points.size(); ++i)
+  for (size_t i = 0; i < traj.points.size(); ++i)
   {
     const trajectory_msgs::JointTrajectoryPoint &pt = traj.points[i];
 
@@ -672,7 +672,7 @@ bool JointTrajectoryInterface::is_valid(const trajectory_msgs::JointTrajectory &
       ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %d", i);
 
     // check for joint velocity limits
-    for (int j = 0; j < pt.velocities.size(); ++j)
+    for (size_t j = 0; j < pt.velocities.size(); ++j)
     {
       std::map<std::string, double>::iterator max_vel = joint_vel_limits_.find(traj.joint_names[j]);
       if (max_vel == joint_vel_limits_.end()) continue;  // no velocity-checking if limit not defined
@@ -691,7 +691,7 @@ bool JointTrajectoryInterface::is_valid(const trajectory_msgs::JointTrajectory &
 
 bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajectory &traj)
 {
-  for (int i = 0; i < traj.points.size(); ++i)
+  for (size_t i = 0; i < traj.points.size(); ++i)
   {
     for (int gr = 0; gr < traj.points[i].num_groups; gr++)
     {
@@ -701,7 +701,7 @@ bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajecto
       if (pt.positions.empty())
         ROS_ERROR_RETURN(false, "Validation failed: Missing position data for trajectory pt %d", i);
       // check for joint velocity limits
-      for (int j = 0; j < pt.velocities.size(); ++j)
+      for (size_t j = 0; j < pt.velocities.size(); ++j)
       {
         std::map<std::string, double>::iterator max_vel = joint_vel_limits_.find(traj.joint_names[j]);
         if (max_vel == joint_vel_limits_.end()) continue;  // no velocity-checking if limit not defined

--- a/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
+++ b/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
@@ -61,7 +61,7 @@ bool getJointGroups(const std::string topic_param, std::map<int, RobotGroup> & r
     }
 
 
-    for (int i = 0; i < topics_list.size(); i++)
+    for (size_t i = 0; i < topics_list.size(); i++)
     {
       ROS_INFO_STREAM("Loading group: " << topics_list[i]);
       RobotGroup rg;

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -489,7 +489,7 @@ bool MotomanJointTrajectoryStreamer::is_valid(const trajectory_msgs::JointTrajec
 
     // FS100 requires valid velocity data
     if (pt.velocities.empty())
-      ROS_ERROR_RETURN(false, "Validation failed: Missing velocity data for trajectory pt %d", i);
+      ROS_ERROR_RETURN(false, "Validation failed: Missing velocity data for trajectory pt %lu", i);
   }
 
   if ((cur_joint_pos_.header.stamp - ros::Time::now()).toSec() > pos_stale_time_)
@@ -522,7 +522,7 @@ bool MotomanJointTrajectoryStreamer::is_valid(const motoman_msgs::DynamicJointTr
       group_number = pt.group_number;
       // FS100 requires valid velocity data
       if (pt.velocities.empty())
-        ROS_ERROR_RETURN(false, "Validation failed: Missing velocity data for trajectory pt %d", i);
+        ROS_ERROR_RETURN(false, "Validation failed: Missing velocity data for trajectory pt %lu", i);
 
       // FS100 requires trajectory start at current position
       namespace IRC_utils = industrial_robot_client::utils;

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -76,7 +76,7 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   rtn &= JointTrajectoryStreamer::init(connection, robot_groups, velocity_limits);
 
   motion_ctrl_.init(connection, 0);
-  for (int i = 0; i < robot_groups_.size(); i++)
+  for (size_t i = 0; i < robot_groups_.size(); i++)
   {
     MotomanMotionCtrl motion_ctrl;
 
@@ -358,7 +358,7 @@ bool MotomanJointTrajectoryStreamer::VectorToJointData(const std::vector<double>
                      (int)vec.size(), joints.getMaxNumJoints());
 
   joints.init();
-  for (int i = 0; i < vec.size(); ++i)
+  for (size_t i = 0; i < vec.size(); ++i)
   {
     joints.setJoint(i, vec[i]);
   }
@@ -483,7 +483,7 @@ bool MotomanJointTrajectoryStreamer::is_valid(const trajectory_msgs::JointTrajec
   if (!JointTrajectoryInterface::is_valid(traj))
     return false;
 
-  for (int i = 0; i < traj.points.size(); ++i)
+  for (size_t i = 0; i < traj.points.size(); ++i)
   {
     const trajectory_msgs::JointTrajectoryPoint &pt = traj.points[i];
 
@@ -512,7 +512,7 @@ bool MotomanJointTrajectoryStreamer::is_valid(const motoman_msgs::DynamicJointTr
     return false;
   ros::Time time_stamp;
   int group_number;
-  for (int i = 0; i < traj.points.size(); ++i)
+  for (size_t i = 0; i < traj.points.size(); ++i)
   {
     for (int gr = 0; gr < traj.points[i].num_groups; gr++)
     {

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -353,7 +353,7 @@ bool MotomanJointTrajectoryStreamer::create_message(int seq, const motoman_msgs:
 bool MotomanJointTrajectoryStreamer::VectorToJointData(const std::vector<double> &vec,
     JointData &joints)
 {
-  if (vec.size() > joints.getMaxNumJoints())
+  if (static_cast<int>(vec.size()) > joints.getMaxNumJoints())
     ROS_ERROR_RETURN(false, "Failed to copy to JointData.  Len (%d) out of range (0 to %d)",
                      (int)vec.size(), joints.getMaxNumJoints());
 

--- a/motoman_driver/src/simple_message/joint_traj_pt_full_ex.cpp
+++ b/motoman_driver/src/simple_message/joint_traj_pt_full_ex.cpp
@@ -114,7 +114,7 @@ bool JointTrajPtFullEx::load(industrial::byte_array::ByteArray *buffer)
     return false;
   }
 
-  for (int i = 0; i < joint_trajectory_points_.size(); i++)
+  for (size_t i = 0; i < joint_trajectory_points_.size(); i++)
   {
     JointTrajPtFull traj_full = joint_trajectory_points_[i];
 
@@ -206,7 +206,7 @@ bool JointTrajPtFullEx::unload(industrial::byte_array::ByteArray *buffer)
 {
   LOG_COMM("Executing joint traj. pt. unload");
 
-  for (int i = 0; i < joint_trajectory_points_.size(); i++)
+  for (size_t i = 0; i < joint_trajectory_points_.size(); i++)
   {
     if (!buffer->unload(joint_trajectory_points_[i]))
     {


### PR DESCRIPTION
Changed for loop index variables to use size_t when comparing with vector size and corresponding ROS console output format string to %lu, JointFeedbackExRelayHandler create_messages now has return value