### PR TITLE
CI Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ env:
 
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=ros
-    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=ros-shadow-fixed
+    - env: ROS_DISTRO="indigo" ROS_REPO=ros
+    - env: ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ env:
     - ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
     - ROS_DISTRO="kinetic" ROS_REPO=ros
     - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO="melodic" ROS_REPO=ros
+    - ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
 
 matrix:
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPO=ros
     - env: ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
     - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
+    - env: ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 language: generic
 
 cache:
@@ -22,5 +20,5 @@ matrix:
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache:
   directories:
     - $HOME/.ccache
 
+services:
+  - docker
+
 env:
   global:
     - CCACHE_DIR=$HOME/.ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,18 @@ env:
     - CCACHE_DIR=$HOME/.ccache
   matrix:
     - ROS_DISTRO="indigo" ROS_REPO=ros
-    - ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO="indigo" ROS_REPO=ros-testing
     - ROS_DISTRO="kinetic" ROS_REPO=ros
-    - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO="kinetic" ROS_REPO=ros-testing
     - ROS_DISTRO="melodic" ROS_REPO=ros
-    - ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO="melodic" ROS_REPO=ros-testing
 
 matrix:
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPO=ros
-    - env: ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
-    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
-    - env: ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
+    - env: ROS_DISTRO="indigo" ROS_REPO=ros-testing
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-testing
+    - env: ROS_DISTRO="melodic" ROS_REPO=ros-testing
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
CI for the ROS Kinetic shadow-fixed repository is currently broken by a few MoveIt packages (as of the merge of #299). This PR updates the CI config to ignore failures in shadow-fixed repositories