### PR TITLE
sda10: fix group mapping

### DIFF
--- a/motoman_sda10f_support/config/sda10f_motion_interface.yaml
+++ b/motoman_sda10f_support/config/sda10f_motion_interface.yaml
@@ -1,17 +1,17 @@
 topic_list:
     - name: sda10f_r1_controller
       ns: sda10f
-      group: 1
+      group: 0
       joints: ['arm_left_joint_1_s','arm_left_joint_2_l','arm_left_joint_3_e','arm_left_joint_4_u','arm_left_joint_5_r','arm_left_joint_6_b','arm_left_joint_7_t']
     - name: sda10f_r2_controller
       ns: sda10f
-      group: 2
+      group: 1
       joints: ['arm_right_joint_1_s','arm_right_joint_2_l','arm_right_joint_3_e','arm_right_joint_4_u','arm_right_joint_5_r','arm_right_joint_6_b','arm_right_joint_7_t']
     - name: sda10f_b1_controller
       ns: sda10f
-      group: 3
+      group: 2
       joints: ['torso_joint_b1']
     - name: sda10f_b2_controller
       ns: sda10f
-      group: 4
+      group: 3
       joints: ['torso_joint_b2']


### PR DESCRIPTION
As per subject.

The groups are actually `0, 1, 2, 3`, not `1, 2, 3, 4`.
