### PR TITLE
Fixed serialization for WriteSingleIO.

### DIFF
--- a/motoman_driver/src/simple_message/motoman_write_single_io.cpp
+++ b/motoman_driver/src/simple_message/motoman_write_single_io.cpp
@@ -109,7 +109,7 @@ bool WriteSingleIO::unload(industrial::byte_array::ByteArray *buffer)
 {
   LOG_COMM("Executing WriteSingleIO command unload");
 
-  if (!buffer->load(this->value_))
+  if (!buffer->unload(this->value_))
   {
     LOG_ERROR("Failed to unload WriteSingleIO value");
     return false;


### PR DESCRIPTION
Fixing a simple typo that was preventing proper deserialization of WriteSingleIO commands on PC/ROS side (such as using a simulator for the Motoman Controller).