### PR TITLE
Rebase of MotomanIoCtrl on-top of current HEAD - initial IO support (ROS side)

### DIFF
--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -119,7 +119,8 @@ set_target_properties(motoman_robot_state
 add_executable(motoman_motion_streaming_interface
   src/joint_streaming_node.cpp
   src/joint_trajectory_streamer.cpp
-  src/motion_ctrl.cpp)
+  src/motion_ctrl.cpp
+  src/io_ctrl.cpp)
 target_link_libraries(motoman_motion_streaming_interface
   motoman_simple_message
   motoman_industrial_robot_client
@@ -160,7 +161,8 @@ set_target_properties(motoman_robot_state_bswap
 add_executable(motoman_motion_streaming_interface_bswap
   src/joint_streaming_node.cpp
   src/joint_trajectory_streamer.cpp
-  src/motion_ctrl.cpp)
+  src/motion_ctrl.cpp
+  src/io_ctrl.cpp)
 target_link_libraries(motoman_motion_streaming_interface_bswap
   motoman_simple_message_bswap
   motoman_industrial_robot_client_bswap

--- a/motoman_driver/include/motoman_driver/io_ctrl.h
+++ b/motoman_driver/include/motoman_driver/io_ctrl.h
@@ -1,0 +1,101 @@
+﻿/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2016, Delft Robotics Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of the Delft Robotics Institute, nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \author G.A. vd. Hoorn (TU Delft Robotics Institute)
+ */
+
+#ifndef MOTOMAN_DRIVER_IO_CTRL_H
+#define MOTOMAN_DRIVER_IO_CTRL_H
+
+#include "simple_message/smpl_msg_connection.h"
+#include "motoman_driver/simple_message/motoman_read_single_io.h"
+#include "motoman_driver/simple_message/motoman_read_single_io_reply.h"
+#include "motoman_driver/simple_message/motoman_write_single_io.h"
+#include "motoman_driver/simple_message/motoman_write_single_io_reply.h"
+
+namespace motoman
+{
+namespace io_ctrl
+{
+using industrial::smpl_msg_connection::SmplMsgConnection;
+using motoman::simple_message::io_ctrl_reply::ReadSingleIOReply;
+using motoman::simple_message::io_ctrl_reply::WriteSingleIOReply;
+
+/**
+ * \brief Wrapper class around Motoman-specific io control commands
+ */
+
+class MotomanIoCtrl
+{
+public:
+  /**
+   * \brief Default constructor
+   */
+  MotomanIoCtrl() {}
+
+  bool init(SmplMsgConnection* connection);
+
+public:
+  /**
+   * \brief Reads a single IO point on the controller.
+   *
+   * Note: if reading was unsuccessful, the value of value is undefined.
+   *
+   * \param address The address (index) of the IO point
+   * \param value [out] Will contain the value of the IO point
+   * \return True IFF reading was successful
+   */
+  bool readSingleIO(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int &value);
+
+  /**
+   * \brief Writes to a single IO point on the controller.
+   *
+   * \param address The address (index) of the IO point
+   * \param value The value to set the IO element to
+   * \return True IFF writing was successful
+   */
+  bool writeSingleIO(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int value);
+
+protected:
+  SmplMsgConnection* connection_;
+
+  bool sendAndReceive(industrial::shared_types::shared_int address,
+    ReadSingleIOReply &reply);
+  bool sendAndReceive(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int value,
+    WriteSingleIOReply &reply);
+};
+
+}  // namespace io_ctrl
+}  // namespace motoman
+
+#endif  // MOTOMAN_DRIVER_IO_CTRL_H

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -40,6 +40,9 @@
 #include "simple_message/joint_data.h"
 #include "simple_message/simple_message.h"
 #include "std_srvs/Trigger.h"
+#include "motoman_driver/io_ctrl.h"
+#include "motoman_msgs/ReadSingleIO.h"
+#include "motoman_msgs/WriteSingleIO.h"
 
 namespace motoman
 {
@@ -47,6 +50,7 @@ namespace joint_trajectory_streamer
 {
 
 using motoman::motion_ctrl::MotomanMotionCtrl;
+using motoman::io_ctrl::MotomanIoCtrl;
 using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreamer;
 using industrial::simple_message::SimpleMessage;
 using industrial::smpl_msg_connection::SmplMsgConnection;
@@ -133,8 +137,17 @@ protected:
 
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;
+  MotomanIoCtrl io_ctrl_;
 
   std::map<int, MotomanMotionCtrl> motion_ctrl_map_;
+
+  ros::ServiceServer srv_read_single_io;   // handle for read_single_io service
+  ros::ServiceServer srv_write_single_io;   // handle for write_single_io service
+
+  bool readSingleIoCB(motoman_msgs::ReadSingleIO::Request &req,
+                            motoman_msgs::ReadSingleIO::Response &res);
+  bool writeSingleIoCB(motoman_msgs::WriteSingleIO::Request &req,
+                            motoman_msgs::WriteSingleIO::Response &res);
 
   void trajectoryStop();
   bool is_valid(const trajectory_msgs::JointTrajectory &traj);

--- a/motoman_driver/src/io_ctrl.cpp
+++ b/motoman_driver/src/io_ctrl.cpp
@@ -1,0 +1,144 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2016, Delft Robotics Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of the Delft Robotics Institute, nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \author G.A. vd. Hoorn (TU Delft Robotics Institute)
+ */
+
+#include "motoman_driver/io_ctrl.h"
+#include "motoman_driver/simple_message/messages/motoman_read_single_io_message.h"
+#include "motoman_driver/simple_message/messages/motoman_read_single_io_reply_message.h"
+#include "motoman_driver/simple_message/messages/motoman_write_single_io_message.h"
+#include "motoman_driver/simple_message/messages/motoman_write_single_io_reply_message.h"
+#include "ros/ros.h"
+#include "simple_message/simple_message.h"
+#include <string>
+
+
+namespace ReadSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResults;
+namespace WriteSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResults;
+
+using motoman::simple_message::io_ctrl::ReadSingleIO;
+using motoman::simple_message::io_ctrl_message::ReadSingleIOMessage;
+using motoman::simple_message::io_ctrl_reply_message::ReadSingleIOReplyMessage;
+using motoman::simple_message::io_ctrl::WriteSingleIO;
+using motoman::simple_message::io_ctrl_message::WriteSingleIOMessage;
+using motoman::simple_message::io_ctrl_reply_message::WriteSingleIOReplyMessage;
+using industrial::simple_message::SimpleMessage;
+using industrial::shared_types::shared_int;
+
+
+namespace motoman
+{
+namespace io_ctrl
+{
+
+bool MotomanIoCtrl::init(SmplMsgConnection* connection)
+{
+  connection_ = connection;
+  return true;
+}
+
+bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value)
+{
+  ReadSingleIOReply reply;
+
+  if (!sendAndReceive(address, reply))
+  {
+    ROS_ERROR("Failed to send READ_SINGLE_IO command");
+    return false;
+  }
+
+  value = reply.getValue();
+
+  return (reply.getResultCode() == ReadSingleIOReplyResults::SUCCESS);
+}
+
+bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
+{
+  WriteSingleIOReply reply;
+
+  if (!sendAndReceive(address, value, reply))
+  {
+    ROS_ERROR("Failed to send WRITE_SINGLE_IO command");
+    return false;
+  }
+
+  return (reply.getResultCode() == WriteSingleIOReplyResults::SUCCESS);
+}
+
+bool MotomanIoCtrl::sendAndReceive(shared_int address, ReadSingleIOReply &reply)
+{
+  SimpleMessage req, res;
+  ReadSingleIO data;
+  ReadSingleIOMessage read_io_msg;
+  ReadSingleIOReplyMessage read_io_reply;
+
+  data.init(address);
+  read_io_msg.init(data);
+  read_io_msg.toRequest(req);
+
+  if (!this->connection_->sendAndReceiveMsg(req, res))
+  {
+    ROS_ERROR("Failed to send ReadSingleIO message");
+    return false;
+  }
+
+  read_io_reply.init(res);
+  reply.copyFrom(read_io_reply.reply_);
+
+  return true;
+}
+
+bool MotomanIoCtrl::sendAndReceive(shared_int address, shared_int value, WriteSingleIOReply &reply)
+{
+  SimpleMessage req, res;
+  WriteSingleIO data;
+  WriteSingleIOMessage write_io_msg;
+  WriteSingleIOReplyMessage write_io_reply;
+
+  data.init(address, value);
+  write_io_msg.init(data);
+  write_io_msg.toRequest(req);
+
+  if (!this->connection_->sendAndReceiveMsg(req, res))
+  {
+    ROS_ERROR("Failed to send WriteSingleIO message");
+    return false;
+  }
+
+  write_io_reply.init(res);
+  reply.copyFrom(write_io_reply.reply_);
+
+  return true;
+}
+
+} // io_ctrl
+
+} // motoman

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -99,7 +99,6 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   this->srv_write_single_io = this->node_.advertiseService("write_single_io",
       &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
 
-
   return rtn;
 }
 
@@ -122,6 +121,13 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   disabler_ = node_.advertiseService("robot_disable", &MotomanJointTrajectoryStreamer::disableRobotCB, this);
 
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
+
+  // hacking this in here at this place
+  io_ctrl_.init(connection);
+  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
+      &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
+  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
+      &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
 
   return rtn;
 }

--- a/motoman_msgs/CMakeLists.txt
+++ b/motoman_msgs/CMakeLists.txt
@@ -25,6 +25,8 @@ add_service_files(
     srv
   FILES
     CmdJointTrajectoryEx.srv
+    ReadSingleIO.srv
+    WriteSingleIO.srv
 )
 
 generate_messages(

--- a/motoman_msgs/srv/ReadSingleIO.srv
+++ b/motoman_msgs/srv/ReadSingleIO.srv
@@ -1,0 +1,3 @@
+uint32 address
+---
+int32 value

--- a/motoman_msgs/srv/ReadSingleIO.srv
+++ b/motoman_msgs/srv/ReadSingleIO.srv
@@ -1,3 +1,15 @@
+
+# Read (and return) the current value of the IO element at 'address'.
+#
+# Addresses are plain, base-10 integers, as used and displayed by the controller
+# (on the teach pendant for instance).
+#
+# There are no restrictions as to which IO elements can be read, but they have
+# to exist on the controller and be configured correctly.
+#
+# Refer also the Yaskawa Motoman documentation on IO addressing and
+# configuration.
+
 uint32 address
 ---
 int32 value

--- a/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman_msgs/srv/WriteSingleIO.srv
@@ -1,0 +1,3 @@
+uint32 address
+int32 value
+---

--- a/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman_msgs/srv/WriteSingleIO.srv
@@ -1,3 +1,4 @@
+# Writable addresses are Network Inputs #27xxx (or #25xxx on DX100/FS100) and Universal/General Outputs #10xxx
 uint32 address
 int32 value
 ---

--- a/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman_msgs/srv/WriteSingleIO.srv
@@ -1,4 +1,19 @@
-# Writable addresses are Network Inputs #27xxx (or #25xxx on DX100/FS100) and Universal/General Outputs #10xxx
+
+# Write 'value' to the IO element at 'address'.
+#
+# This service does not return anything.
+#
+# Addresses are plain, base-10 integers, as used and displayed by the controller
+# (on the teach pendant for instance).
+#
+# Only the following addresses can be written to:
+#
+#  - 27010 and up : Network Inputs (25010 and up on DX100 and FS100)
+#  - 10010 and up : Universal/General Outputs
+#
+# Refer also the Yaskawa Motoman documentation on IO addressing and
+# configuration.
+
 uint32 address
 int32 value
 ---


### PR DESCRIPTION
This pull request adds support for reading/writing single IO signals for single and multi motion groups.

@marip8 and I were able to test it out on dx200 controller with a single motion group robot.
- Controller software version: DN2.33.00A (JP/US)-00
- MotoROS version: ??
    - @gavanderhoorn @ted-miller how do we determine what version is currently running on the controller?

Notes:
- We were able to read/write universal inputs and outputs, but we were not able to read/write other types (i.e. external, specific, control, network, etc.). @gavanderhoorn is this the intended behavior?
- Leading zeros on addresses were not being interpreted correctly. Example: service request address = 00010 was interpreted as 9. When we put the actual number in there (10 in this case) everything works as expected.