### PR TITLE
Update/separate io control from joint streamer

### DIFF
--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -254,4 +254,7 @@ install(DIRECTORY
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   roslint_cpp()
+
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(tests/roslaunch_test_io_relay.xml)
 endif()

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -184,6 +184,20 @@ set_target_properties(motoman_motion_streaming_interface_bswap
   PROPERTIES OUTPUT_NAME motion_streaming_interface_bswap
   PREFIX "")
 
+# I/O relay node
+add_executable(motoman_io_relay_bswap
+  src/io_relay_node.cpp
+  src/io_relay.cpp
+  src/io_ctrl.cpp)
+target_link_libraries(motoman_io_relay_bswap
+  motoman_simple_message_bswap
+  motoman_industrial_robot_client_bswap
+  ${catkin_LIBRARIES})
+set_target_properties(motoman_io_relay_bswap
+  PROPERTIES OUTPUT_NAME io_relay_bswap
+  PREFIX "")
+
+
 add_executable(${PROJECT_NAME}_joint_trajectory_action
   src/industrial_robot_client/joint_trajectory_action.cpp
   src/joint_trajectory_action_node.cpp)

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -214,6 +214,8 @@ target_link_libraries(${PROJECT_NAME}_joint_trajectory_action
 # binaries
 install(TARGETS
   ${PROJECT_NAME}_joint_trajectory_action
+  motoman_io_relay
+  motoman_io_relay_bswap
   motoman_motion_streaming_interface
   motoman_motion_streaming_interface_bswap
   motoman_robot_state

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -129,6 +129,19 @@ set_target_properties(motoman_motion_streaming_interface
   PROPERTIES OUTPUT_NAME motion_streaming_interface
   PREFIX "")
 
+# I/O relay node
+add_executable(motoman_io_relay
+  src/io_relay_node.cpp
+  src/io_relay.cpp
+  src/io_ctrl.cpp)
+target_link_libraries(motoman_io_relay
+  motoman_simple_message
+  motoman_industrial_robot_client
+  ${catkin_LIBRARIES})
+set_target_properties(motoman_io_relay
+  PROPERTIES OUTPUT_NAME motoman_io_relay
+  PREFIX "")
+
 
 #----------------------------------------------------------------
 # FS100 uses opposite byte-ordering from most i386-based PCs

--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -139,7 +139,7 @@ target_link_libraries(motoman_io_relay
   motoman_industrial_robot_client
   ${catkin_LIBRARIES})
 set_target_properties(motoman_io_relay
-  PROPERTIES OUTPUT_NAME motoman_io_relay
+  PROPERTIES OUTPUT_NAME io_relay
   PREFIX "")
 
 

--- a/motoman_driver/include/motoman_driver/io_ctrl.h
+++ b/motoman_driver/include/motoman_driver/io_ctrl.h
@@ -1,7 +1,7 @@
 ﻿/*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2016, Delft Robotics Institute
+ * Copyright (c) 2020, Delft Robotics Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/motoman_driver/include/motoman_driver/io_relay.h
+++ b/motoman_driver/include/motoman_driver/io_relay.h
@@ -54,11 +54,10 @@ public:
   /**
    * \brief Class initializer
    *
-   * \param default_ip
    * \param default_port
    * \return true on success, false otherwise
    */
-  bool init(std::string default_ip, int default_port);
+  bool init(int default_port);
 
 protected:
   io_ctrl::MotomanIoCtrl io_ctrl_;

--- a/motoman_driver/include/motoman_driver/io_relay.h
+++ b/motoman_driver/include/motoman_driver/io_relay.h
@@ -55,10 +55,10 @@ public:
    * \brief Class initializer
    *
    * \param default_ip
-   * \param version_0
+   * \param default_port
    * \return true on success, false otherwise
    */
-  bool init(std::string default_ip, bool version_0);
+  bool init(std::string default_ip, int default_port);
 
 protected:
   io_ctrl::MotomanIoCtrl io_ctrl_;

--- a/motoman_driver/include/motoman_driver/io_relay.h
+++ b/motoman_driver/include/motoman_driver/io_relay.h
@@ -46,7 +46,7 @@ namespace io_relay
 using industrial::tcp_client::TcpClient;
 
 /**
- * \brief Message handler that streams I/O control to the robot controller.
+ * \brief Message handler that sends I/O service requests to the robot controller and receives the responses.
  */
 class MotomanIORelay
 {

--- a/motoman_driver/include/motoman_driver/io_relay.h
+++ b/motoman_driver/include/motoman_driver/io_relay.h
@@ -1,0 +1,82 @@
+﻿/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2013, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *       * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *       * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *       * Neither the name of the Southwest Research Institute, nor the names
+ *       of its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOTOMAN_DRIVER_IO_RELAY_H
+#define MOTOMAN_DRIVER_IO_RELAY_H
+
+#include "simple_message/socket/tcp_client.h"
+#include "motoman_driver/io_ctrl.h"
+#include "motoman_msgs/ReadSingleIO.h"
+#include "motoman_msgs/WriteSingleIO.h"
+#include <boost/thread.hpp>
+
+namespace motoman
+{
+namespace io_relay
+{
+
+using industrial::tcp_client::TcpClient;
+
+/**
+ * \brief Message handler that streams I/O control to the robot controller.
+ */
+class MotomanIORelay
+{
+public:
+  /**
+   * \brief Class initializer
+   *
+   * \param default_ip
+   * \param version_0
+   * \return true on success, false otherwise
+   */
+  bool init(std::string default_ip, bool version_0);
+
+protected:
+  io_ctrl::MotomanIoCtrl io_ctrl_;
+
+  ros::ServiceServer srv_read_single_io;   // handle for read_single_io service
+  ros::ServiceServer srv_write_single_io;   // handle for write_single_io service
+
+  ros::NodeHandle node_;
+  boost::mutex mutex_;
+  TcpClient default_tcp_connection_;
+
+  bool readSingleIoCB(motoman_msgs::ReadSingleIO::Request &req,
+                            motoman_msgs::ReadSingleIO::Response &res);
+  bool writeSingleIoCB(motoman_msgs::WriteSingleIO::Request &req,
+                            motoman_msgs::WriteSingleIO::Response &res);
+};
+
+}  // namespace io_relay
+}  // namespace motoman
+
+#endif  // MOTOMAN_DRIVER_IO_RELAY_H

--- a/motoman_driver/include/motoman_driver/io_relay.h
+++ b/motoman_driver/include/motoman_driver/io_relay.h
@@ -1,7 +1,7 @@
 ﻿/*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, Southwest Research Institute
+ * Copyright (c) 2020, Southwest Research Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -40,9 +40,6 @@
 #include "simple_message/joint_data.h"
 #include "simple_message/simple_message.h"
 #include "std_srvs/Trigger.h"
-#include "motoman_driver/io_ctrl.h"
-#include "motoman_msgs/ReadSingleIO.h"
-#include "motoman_msgs/WriteSingleIO.h"
 
 namespace motoman
 {
@@ -50,7 +47,6 @@ namespace joint_trajectory_streamer
 {
 
 using motoman::motion_ctrl::MotomanMotionCtrl;
-using motoman::io_ctrl::MotomanIoCtrl;
 using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreamer;
 using industrial::simple_message::SimpleMessage;
 using industrial::smpl_msg_connection::SmplMsgConnection;
@@ -137,17 +133,8 @@ protected:
 
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;
-  MotomanIoCtrl io_ctrl_;
 
   std::map<int, MotomanMotionCtrl> motion_ctrl_map_;
-
-  ros::ServiceServer srv_read_single_io;   // handle for read_single_io service
-  ros::ServiceServer srv_write_single_io;   // handle for write_single_io service
-
-  bool readSingleIoCB(motoman_msgs::ReadSingleIO::Request &req,
-                            motoman_msgs::ReadSingleIO::Response &res);
-  bool writeSingleIoCB(motoman_msgs::WriteSingleIO::Request &req,
-                            motoman_msgs::WriteSingleIO::Response &res);
 
   void trajectoryStop();
   bool is_valid(const trajectory_msgs::JointTrajectory &traj);

--- a/motoman_driver/launch/io_relay.launch
+++ b/motoman_driver/launch/io_relay.launch
@@ -5,8 +5,15 @@
   <!-- IP of robot (or PC running simulation) -->
   <arg name="robot_ip" doc="IP of controller" />
 
+  <!-- Load the byte-swapping version of io_relay if required -->
+  <arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+
   <!-- put them on the parameter server -->
   <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-  <node name="io_relay" pkg="motoman_driver" type="io_relay" />
+  <!-- load the correct version of the io relay node -->
+  <node if="$(arg use_bswap)" name="io_relay"
+        pkg="motoman_driver" type="io_relay_bswap" />
+  <node unless="$(arg use_bswap)" name="io_relay"
+        pkg="motoman_driver" type="io_relay" />
 </launch>

--- a/motoman_driver/launch/io_relay.launch
+++ b/motoman_driver/launch/io_relay.launch
@@ -2,11 +2,11 @@
   Wrapper launch file for I/O relay node.
 -->
 <launch>
-	<!-- IP of robot (or PC running simulation) -->
-	<arg name="robot_ip" doc="IP of controller" />
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" doc="IP of controller" />
 
-	<!-- put them on the parameter server -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-        <node name="io_relay" pkg="motoman_driver" type="io_relay" />
+  <node name="io_relay" pkg="motoman_driver" type="io_relay" />
 </launch>

--- a/motoman_driver/launch/io_relay.launch
+++ b/motoman_driver/launch/io_relay.launch
@@ -1,0 +1,12 @@
+<!-- 
+  Wrapper launch file for I/O relay node.
+-->
+<launch>
+	<!-- IP of robot (or PC running simulation) -->
+	<arg name="robot_ip" doc="IP of controller" />
+
+	<!-- put them on the parameter server -->
+	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+        <node name="io_relay" pkg="motoman_driver" type="io_relay" />
+</launch>

--- a/motoman_driver/launch/motion_streaming_interface.launch
+++ b/motoman_driver/launch/motion_streaming_interface.launch
@@ -2,18 +2,18 @@
   Wrapper launch file for the Fanuc specific motion streaming interface node.
 -->
 <launch>
-	<!-- IP of robot (or PC running simulation) -->
-	<arg name="robot_ip" doc="IP of controller" />
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" doc="IP of controller" />
 
-	<!-- Load the byte-swapping version of robot_state if required -->
-	<arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <!-- Load the byte-swapping version of robot_state if required -->
+  <arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!-- put them on the parameter server -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-	<!-- load the correct version of the motion streaming node -->
-	<node if="$(arg use_bswap)" name="motion_streaming_interface"
-		pkg="motoman_driver" type="motion_streaming_interface_bswap" />
-	<node unless="$(arg use_bswap)" name="motion_streaming_interface"
-		pkg="motoman_driver" type="motion_streaming_interface" />
+  <!-- load the correct version of the motion streaming node -->
+  <node if="$(arg use_bswap)" name="motion_streaming_interface"
+        pkg="motoman_driver" type="motion_streaming_interface_bswap" />
+  <node unless="$(arg use_bswap)" name="motion_streaming_interface"
+        pkg="motoman_driver" type="motion_streaming_interface" />
 </launch>

--- a/motoman_driver/launch/robot_interface_streaming.launch
+++ b/motoman_driver/launch/robot_interface_streaming.launch
@@ -44,6 +44,14 @@
 		<arg name="use_bswap"  value="$(arg use_bswap)" />
 	</include>
 
+	<!-- io_relay: sends and receives IO reads/writes to the controller
+	     (using socket connection to robot)
+	-->
+	<include file="$(find motoman_driver)/launch/io_relay.launch">
+		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="use_bswap"  value="$(arg use_bswap)" />
+	</include>
+
 	<!-- joint_trajectory_action: provides actionlib interface for 
 	     high-level robot control
 	-->

--- a/motoman_driver/package.xml
+++ b/motoman_driver/package.xml
@@ -18,6 +18,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
   <test_depend>roslint</test_depend>
 
   <depend>actionlib</depend>

--- a/motoman_driver/src/io_ctrl.cpp
+++ b/motoman_driver/src/io_ctrl.cpp
@@ -62,7 +62,6 @@ namespace io_ctrl
 bool MotomanIoCtrl::init(SmplMsgConnection* connection)
 {
   connection_ = connection;
-  connection_->makeConnect();
   return true;
 }
 

--- a/motoman_driver/src/io_ctrl.cpp
+++ b/motoman_driver/src/io_ctrl.cpp
@@ -62,6 +62,7 @@ namespace io_ctrl
 bool MotomanIoCtrl::init(SmplMsgConnection* connection)
 {
   connection_ = connection;
+  connection_->makeConnect();
   return true;
 }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -46,7 +46,6 @@ bool MotomanIORelay::init(int default_port)
   std::string ip;
   int port;
 
-  ros::param::get("robot_ip_address", ip);
   // override port with ROS param, if available
   const std::string port_param_name = "~port";
   // TODO: should really use a private NodeHandle here
@@ -56,10 +55,11 @@ bool MotomanIORelay::init(int default_port)
       << "' parameter: using default (" << default_port << ")");
   }
 
-  // check for valid parameter values
-  if (ip.empty())
+  const std::string robot_ip_param_name = "robot_ip_address";
+  if(!ros::param::get(robot_ip_param_name, ip) || ip.empty())
   {
-    ROS_ERROR_NAMED("io.init", "No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
+    ROS_FATAL_STREAM_NAMED("io.init", "Invalid IP address: please set the '"
+      << robot_ip_param_name << "' parameter");
     return false;
   }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -48,8 +48,13 @@ bool MotomanIORelay::init(int default_port)
 
   ros::param::get("robot_ip_address", ip);
   // override port with ROS param, if available
-  ros::param::param<int>("~port", port, default_port);
-  ROS_DEBUG_NAMED("io.init", "Using port: %d (default was: %d)", port, default_port);
+  const std::string port_param_name = "~port";
+  // TODO: should really use a private NodeHandle here
+  if(!ros::param::param<int>(port_param_name, port, default_port))
+  {
+    ROS_WARN_STREAM_NAMED("io.init", "Failed to get '" << port_param_name
+      << "' parameter: using default (" << default_port << ")");
+  }
 
   // check for valid parameter values
   if (ip.empty())

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -73,7 +73,7 @@ bool MotomanIORelay::init(int default_port)
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
   if (!default_tcp_connection_.init(ip_addr, port))
   {
-    ROS_ERROR_NAMED("io.init", "Failed to initialize TcpClient");
+    ROS_FATAL_NAMED("io.init", "Failed to initialize TcpClient");
     return false;
   }
   free(ip_addr);
@@ -81,13 +81,13 @@ bool MotomanIORelay::init(int default_port)
   ROS_DEBUG_STREAM_NAMED("io.init", "I/O relay attempting to connect to: tcp://" << ip << ":" << port);
   if (!default_tcp_connection_.makeConnect())
   {
-    ROS_ERROR_NAMED("io.init", "Failed to connect");
+    ROS_FATAL_NAMED("io.init", "Failed to connect");
     return false;
   }
 
   if (!io_ctrl_.init(&default_tcp_connection_))
   {
-    ROS_ERROR_NAMED("io.init", "Failed to initialize MotomanIoCtrl");
+    ROS_FATAL_NAMED("io.init", "Failed to initialize MotomanIoCtrl");
     return false;
   }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,7 +43,7 @@ using industrial::shared_types::shared_int;
 
 bool MotomanIORelay::init(int default_port)
 {
-  ROS_INFO("MotomanIORelay: init");
+  ROS_DEBUG_NAMED("init", "MotomanIORelay::init(default_port = %d)", default_port);
 
   std::string ip;
   int port;
@@ -55,12 +55,12 @@ bool MotomanIORelay::init(int default_port)
   // check for valid parameter values
   if (ip.empty())
   {
-    ROS_ERROR("No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
+    ROS_ERROR_NAMED("init", "No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
     return false;
   }
 
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
-  ROS_INFO("I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
+  ROS_DEBUG_NAMED("init", "I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
   default_tcp_connection_.init(ip_addr, port);
   free(ip_addr);
   default_tcp_connection_.makeConnect();
@@ -88,11 +88,11 @@ bool MotomanIORelay::readSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR("Reading IO element %d failed", req.address);
+    ROS_ERROR_NAMED("read", "Reading IO element %d failed", req.address);
     return false;
   }
   res.value = io_val;
-  ROS_INFO("Element %d value: %d", req.address, io_val);
+  ROS_DEBUG_NAMED("read", "Element %d value: %d", req.address, io_val);
 
   return true;
 }
@@ -112,10 +112,10 @@ bool MotomanIORelay::writeSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR("Writing IO element %d failed", req.address);
+    ROS_ERROR_NAMED("write", "Writing IO element %d failed", req.address);
     return false;
   }
-  ROS_INFO("Element %d set to: %d", req.address, req.value);
+  ROS_DEBUG_NAMED("write", "Element %d set to: %d", req.address, req.value);
 
   return true;
 }

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -33,12 +33,12 @@
 #include <string>
 #include <ros/ros.h>
 
-using industrial::shared_types::shared_int;
-
 namespace motoman
 {
 namespace io_relay
 {
+
+using industrial::shared_types::shared_int;
 
 bool MotomanIORelay::init(int default_port)
 {

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,15 +43,15 @@ namespace io_relay
 // TODO: is this needed?
 #define ROS_ERROR_RETURN(rtn,...) do {ROS_ERROR(__VA_ARGS__); return(rtn);} while(0)
 
-bool MotomanIORelay::init(std::string default_ip, int default_port)
+bool MotomanIORelay::init(int default_port)
 {
   ROS_INFO("MotomanIORelay: init");
 
   std::string ip;
   int port;
 
-  // override IP/port with ROS params, if available
-  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::get("robot_ip_address", ip);
+  // override port with ROS param, if available
   ros::param::param<int>("~port", port, default_port);
 
   // check for valid parameter values

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -32,6 +32,7 @@
 
 #include "motoman_driver/io_relay.h"
 #include <string>
+#include <limits>
 #include <ros/ros.h>
 
 namespace motoman
@@ -53,6 +54,12 @@ bool MotomanIORelay::init(int default_port)
   {
     ROS_WARN_STREAM_NAMED("io.init", "Failed to get '" << port_param_name
       << "' parameter: using default (" << default_port << ")");
+  }
+  if(port < 0 or port > std::numeric_limits<unsigned short>::max())
+  {
+    ROS_FATAL_STREAM_NAMED("io.init", "Invalid value for port (" << port << "), "
+      "must be between 0 and " << std::numeric_limits<unsigned short>::max() << ".");
+    return false;
   }
 
   const std::string robot_ip_param_name = "robot_ip_address";

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2020, Delft Robotics Institute
+ * Copyright (c) 2016, Delft Robotics Institute
  * Copyright (c) 2020, Southwest Research Institute
  * All rights reserved.
  *

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -1,6 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
+ * Copyright (c) 2020, Delft Robotics Institute
  * Copyright (c) 2020, Southwest Research Institute
  * All rights reserved.
  *

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -61,11 +61,20 @@ bool MotomanIORelay::init(int default_port)
 
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
   ROS_DEBUG_NAMED("init", "I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
-  default_tcp_connection_.init(ip_addr, port);
+  if (!default_tcp_connection_.init(ip_addr, port))
+  {
+    ROS_ERROR_NAMED("init", "Failed to initialize TcpClient");
+    return false;
+  }
   free(ip_addr);
   default_tcp_connection_.makeConnect();
 
-  io_ctrl_.init(&default_tcp_connection_);
+  if (!io_ctrl_.init(&default_tcp_connection_))
+  {
+    ROS_ERROR_NAMED("init", "Failed to initialize MotomanIoCtrl");
+    return false;
+  }
+
   this->srv_read_single_io = this->node_.advertiseService("read_single_io",
       &MotomanIORelay::readSingleIoCB, this);
   this->srv_write_single_io = this->node_.advertiseService("write_single_io",

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -55,7 +55,7 @@ bool MotomanIORelay::init(int default_port)
     ROS_WARN_STREAM_NAMED("io.init", "Failed to get '" << port_param_name
       << "' parameter: using default (" << default_port << ")");
   }
-  if(port < 0 or port > std::numeric_limits<unsigned short>::max())
+  if(port < 0 || port > std::numeric_limits<unsigned short>::max())
   {
     ROS_FATAL_STREAM_NAMED("io.init", "Invalid value for port (" << port << "), "
       "must be between 0 and " << std::numeric_limits<unsigned short>::max() << ".");

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,14 +43,13 @@ using industrial::shared_types::shared_int;
 
 bool MotomanIORelay::init(int default_port)
 {
-  ROS_DEBUG_NAMED("io.init", "Using default port: %d", default_port);
-
   std::string ip;
   int port;
 
   ros::param::get("robot_ip_address", ip);
   // override port with ROS param, if available
   ros::param::param<int>("~port", port, default_port);
+  ROS_DEBUG_NAMED("io.init", "Using port: %d (default was: %d)", port, default_port);
 
   // check for valid parameter values
   if (ip.empty())

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -1,0 +1,125 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2013, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *  * Neither the name of the Southwest Research Institute, nor the names
+ *  of its contributors may be used to endorse or promote products derived
+ *  from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "motoman_driver/io_relay.h"
+#include <string>
+#include <ros/ros.h>
+
+using industrial::shared_types::shared_int;
+
+namespace motoman
+{
+namespace io_relay
+{
+
+// TODO: is this needed?
+#define ROS_ERROR_RETURN(rtn,...) do {ROS_ERROR(__VA_ARGS__); return(rtn);} while(0)
+
+bool MotomanIORelay::init(std::string default_ip, bool version_0)
+{
+  ROS_INFO("MotomanIORelay: init");
+
+  std::string ip;
+  int port = 50242;
+
+  // override IP/port with ROS params, if available
+  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+
+  // check for valid parameter values
+  if (ip.empty())
+  {
+    ROS_ERROR("No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
+    return false;
+  }
+
+  char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
+  ROS_INFO("I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
+  default_tcp_connection_.init(ip_addr, port);
+  free(ip_addr);
+
+  io_ctrl_.init(&default_tcp_connection_);
+  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
+      &MotomanIORelay::readSingleIoCB, this);
+  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
+      &MotomanIORelay::writeSingleIoCB, this);
+
+  return true;
+}
+
+// Service to read a single IO
+bool MotomanIORelay::readSingleIoCB(
+  motoman_msgs::ReadSingleIO::Request &req,
+  motoman_msgs::ReadSingleIO::Response &res)
+{
+  shared_int io_val= -1;
+
+  // send message and release mutex as soon as possible
+  this->mutex_.lock();
+  bool result = io_ctrl_.readSingleIO(req.address, io_val);
+  this->mutex_.unlock();
+
+  if (!result)
+  {
+    ROS_ERROR("Reading IO element %d failed", req.address);
+    return false;
+  }
+  res.value = io_val;
+  ROS_INFO("Element %d value: %d", req.address, io_val);
+
+  return true;
+}
+
+
+// Service to write Single IO
+bool MotomanIORelay::writeSingleIoCB(
+  motoman_msgs::WriteSingleIO::Request &req,
+  motoman_msgs::WriteSingleIO::Response &res)
+{
+  shared_int io_val= -1;
+
+  // send message and release mutex as soon as possible
+  this->mutex_.lock();
+  bool result = io_ctrl_.writeSingleIO(req.address, req.value);
+  this->mutex_.unlock();
+
+  if (!result)
+  {
+    ROS_ERROR("Writing IO element %d failed", req.address);
+    return false;
+  }
+  ROS_INFO("Element %d set to: %d", req.address, req.value);
+
+  return true;
+}
+
+}  // namespace io_relay
+}  // namespace motoman
+

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -59,7 +59,6 @@ bool MotomanIORelay::init(int default_port)
   }
 
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
-  ROS_DEBUG_NAMED("io.init", "I/O relay attempting to connect to: tcp://%s:%d", ip_addr, port);
   if (!default_tcp_connection_.init(ip_addr, port))
   {
     ROS_ERROR_NAMED("io.init", "Failed to initialize TcpClient");
@@ -67,6 +66,7 @@ bool MotomanIORelay::init(int default_port)
   }
   free(ip_addr);
 
+  ROS_DEBUG_STREAM_NAMED("io.init", "I/O relay attempting to connect to: tcp://" << ip << ":" << port);
   if (!default_tcp_connection_.makeConnect())
   {
     ROS_ERROR_NAMED("io.init", "Failed to connect");

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -40,9 +40,6 @@ namespace motoman
 namespace io_relay
 {
 
-// TODO: is this needed?
-#define ROS_ERROR_RETURN(rtn,...) do {ROS_ERROR(__VA_ARGS__); return(rtn);} while(0)
-
 bool MotomanIORelay::init(int default_port)
 {
   ROS_INFO("MotomanIORelay: init");

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,15 +43,16 @@ namespace io_relay
 // TODO: is this needed?
 #define ROS_ERROR_RETURN(rtn,...) do {ROS_ERROR(__VA_ARGS__); return(rtn);} while(0)
 
-bool MotomanIORelay::init(std::string default_ip, bool version_0)
+bool MotomanIORelay::init(std::string default_ip, int default_port)
 {
   ROS_INFO("MotomanIORelay: init");
 
   std::string ip;
-  int port = 50242;
+  int port;
 
   // override IP/port with ROS params, if available
   ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::param<int>("~port", port, default_port);
 
   // check for valid parameter values
   if (ip.empty())

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,7 +43,7 @@ using industrial::shared_types::shared_int;
 
 bool MotomanIORelay::init(int default_port)
 {
-  ROS_DEBUG_NAMED("io.init", "MotomanIORelay::init(default_port = %d)", default_port);
+  ROS_DEBUG_NAMED("io.init", "Using default port: %d", default_port);
 
   std::string ip;
   int port;
@@ -60,7 +60,7 @@ bool MotomanIORelay::init(int default_port)
   }
 
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
-  ROS_DEBUG_NAMED("io.init", "I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
+  ROS_DEBUG_NAMED("io.init", "I/O relay attempting to connect to: tcp://%s:%d", ip_addr, port);
   if (!default_tcp_connection_.init(ip_addr, port))
   {
     ROS_ERROR_NAMED("io.init", "Failed to initialize TcpClient");

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -43,7 +43,7 @@ using industrial::shared_types::shared_int;
 
 bool MotomanIORelay::init(int default_port)
 {
-  ROS_DEBUG_NAMED("init", "MotomanIORelay::init(default_port = %d)", default_port);
+  ROS_DEBUG_NAMED("io.init", "MotomanIORelay::init(default_port = %d)", default_port);
 
   std::string ip;
   int port;
@@ -55,15 +55,15 @@ bool MotomanIORelay::init(int default_port)
   // check for valid parameter values
   if (ip.empty())
   {
-    ROS_ERROR_NAMED("init", "No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
+    ROS_ERROR_NAMED("io.init", "No valid robot IP address found.  Please set ROS 'robot_ip_address' param");
     return false;
   }
 
   char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"
-  ROS_DEBUG_NAMED("init", "I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
+  ROS_DEBUG_NAMED("io.init", "I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
   if (!default_tcp_connection_.init(ip_addr, port))
   {
-    ROS_ERROR_NAMED("init", "Failed to initialize TcpClient");
+    ROS_ERROR_NAMED("io.init", "Failed to initialize TcpClient");
     return false;
   }
   free(ip_addr);
@@ -71,7 +71,7 @@ bool MotomanIORelay::init(int default_port)
 
   if (!io_ctrl_.init(&default_tcp_connection_))
   {
-    ROS_ERROR_NAMED("init", "Failed to initialize MotomanIoCtrl");
+    ROS_ERROR_NAMED("io.init", "Failed to initialize MotomanIoCtrl");
     return false;
   }
 
@@ -97,11 +97,11 @@ bool MotomanIORelay::readSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR_NAMED("read", "Reading IO element %d failed", req.address);
+    ROS_ERROR_NAMED("io.read", "Reading IO element %d failed", req.address);
     return false;
   }
   res.value = io_val;
-  ROS_DEBUG_NAMED("read", "Element %d value: %d", req.address, io_val);
+  ROS_DEBUG_NAMED("io.read", "Element %d value: %d", req.address, io_val);
 
   return true;
 }
@@ -121,10 +121,10 @@ bool MotomanIORelay::writeSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR_NAMED("write", "Writing IO element %d failed", req.address);
+    ROS_ERROR_NAMED("io.write", "Writing IO element %d failed", req.address);
     return false;
   }
-  ROS_DEBUG_NAMED("write", "Element %d set to: %d", req.address, req.value);
+  ROS_DEBUG_NAMED("io.write", "Element %d set to: %d", req.address, req.value);
 
   return true;
 }

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -66,7 +66,12 @@ bool MotomanIORelay::init(int default_port)
     return false;
   }
   free(ip_addr);
-  default_tcp_connection_.makeConnect();
+
+  if (!default_tcp_connection_.makeConnect())
+  {
+    ROS_ERROR_NAMED("io.init", "Failed to connect");
+    return false;
+  }
 
   if (!io_ctrl_.init(&default_tcp_connection_))
   {

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -65,6 +65,7 @@ bool MotomanIORelay::init(std::string default_ip, int default_port)
   ROS_INFO("I/O relay connecting to IP address: '%s:%d'", ip_addr, port);
   default_tcp_connection_.init(ip_addr, port);
   free(ip_addr);
+  default_tcp_connection_.makeConnect();
 
   io_ctrl_.init(&default_tcp_connection_);
   this->srv_read_single_io = this->node_.advertiseService("read_single_io",

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, Southwest Research Institute
+ * Copyright (c) 2020, Southwest Research Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/motoman_driver/src/io_relay_node.cpp
+++ b/motoman_driver/src/io_relay_node.cpp
@@ -35,12 +35,14 @@ using motoman::io_relay::MotomanIORelay;
 
 int main(int argc, char** argv)
 {
+  const int io_port = 50242;
+
   // initialize node
   ros::init(argc, argv, "io_relay");
 
   MotomanIORelay io_relay;
 
-  io_relay.init("", false);
+  io_relay.init("", io_port);
 
   ros::spin();
 

--- a/motoman_driver/src/io_relay_node.cpp
+++ b/motoman_driver/src/io_relay_node.cpp
@@ -35,14 +35,14 @@ using motoman::io_relay::MotomanIORelay;
 
 int main(int argc, char** argv)
 {
-  const int io_port = 50242;
+  const int default_io_port = 50242;
 
   // initialize node
   ros::init(argc, argv, "io_relay");
 
   MotomanIORelay io_relay;
 
-  io_relay.init("", io_port);
+  io_relay.init(default_io_port);
 
   ros::spin();
 

--- a/motoman_driver/src/io_relay_node.cpp
+++ b/motoman_driver/src/io_relay_node.cpp
@@ -1,0 +1,48 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2013, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of the Southwest Research Institute, nor the names
+ *      of its contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "motoman_driver/io_relay.h"
+
+using motoman::io_relay::MotomanIORelay;
+
+int main(int argc, char** argv)
+{
+  // initialize node
+  ros::init(argc, argv, "io_relay");
+
+  MotomanIORelay io_relay;
+
+  io_relay.init("", false);
+
+  ros::spin();
+
+  return 0;
+}

--- a/motoman_driver/src/io_relay_node.cpp
+++ b/motoman_driver/src/io_relay_node.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, Southwest Research Institute
+ * Copyright (c) 2020, Southwest Research Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -51,7 +51,6 @@ using industrial::shared_types::shared_int;
 using motoman::simple_message::motion_reply_message::MotionReplyMessage;
 namespace TransferStates = industrial_robot_client::joint_trajectory_streamer::TransferStates;
 namespace MotionReplyResults = motoman::simple_message::motion_reply::MotionReplyResults;
-using motoman::io_ctrl::MotomanIoCtrl;
 
 namespace motoman
 {
@@ -92,13 +91,6 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
 
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
 
-  // hacking this in here at this place
-  io_ctrl_.init(connection);
-  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
-      &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
-  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
-      &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
-
   return rtn;
 }
 
@@ -121,13 +113,6 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   disabler_ = node_.advertiseService("robot_disable", &MotomanJointTrajectoryStreamer::disableRobotCB, this);
 
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
-
-  // hacking this in here at this place
-  io_ctrl_.init(connection);
-  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
-      &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
-  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
-      &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
 
   return rtn;
 }
@@ -557,56 +542,6 @@ bool MotomanJointTrajectoryStreamer::is_valid(const motoman_msgs::DynamicJointTr
 
   return true;
 }
-
-
-// Service to read a single IO
-bool MotomanJointTrajectoryStreamer::readSingleIoCB(
-  motoman_msgs::ReadSingleIO::Request &req,
-  motoman_msgs::ReadSingleIO::Response &res)
-{
-  shared_int io_val= -1;
-
-  // send message and release mutex as soon as possible
-  this->mutex_.lock();
-  bool result = io_ctrl_.readSingleIO(req.address, io_val);
-  this->mutex_.unlock();
-
-  if (!result)
-  {
-    ROS_ERROR("Reading IO element %d failed", req.address);
-    return false;
-  }
-  res.value = io_val;
-  ROS_INFO("Element %d value: %d", req.address, io_val);
-
-  return true;
-}
-
-
-// Service to write Single IO
-bool MotomanJointTrajectoryStreamer::writeSingleIoCB(
-  motoman_msgs::WriteSingleIO::Request &req,
-  motoman_msgs::WriteSingleIO::Response &res)
-{
-  shared_int io_val= -1;
-
-  // send message and release mutex as soon as possible
-  this->mutex_.lock();
-  bool result = io_ctrl_.writeSingleIO(req.address, req.value);
-  this->mutex_.unlock();
-
-  if (!result)
-  {
-    ROS_ERROR("Writing IO element %d failed", req.address);
-    return false;
-  }
-  ROS_INFO("Element %d set to: %d", req.address, req.value);
-
-  return true;
-}
-
-
-
 
 }  // namespace joint_trajectory_streamer
 }  // namespace motoman

--- a/motoman_driver/tests/roslaunch_test_io_relay.xml
+++ b/motoman_driver/tests/roslaunch_test_io_relay.xml
@@ -1,0 +1,17 @@
+<launch>
+  <arg name="robot_ip" value="127.0.0.1"/>
+
+  <group ns="io_relay">
+    <include file="$(find motoman_driver)/launch/io_relay.launch">
+      <arg name="robot_ip"  value="$(arg robot_ip)" />
+      <arg name="use_bswap" value="false"/>
+    </include>
+  </group>
+
+  <group ns="io_relay_bswap">
+    <include file="$(find motoman_driver)/launch/io_relay.launch">
+      <arg name="robot_ip"  value="$(arg robot_ip)" />
+      <arg name="use_bswap" value="true"/>
+    </include>
+  </group>
+</launch>


### PR DESCRIPTION
This pull request addresses the need to move I/O control out of the ```motion_interface``` node and into a new ```io_relay``` node.

This is for #361.
