### PR TITLE
Add success and message fields to IO services

### DIFF
--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -114,11 +114,14 @@ bool MotomanIORelay::readSingleIoCB(
 
   if (!result)
   {
-    std::stringstream message;
-    message << "Reading IO element " << req.address << " failed";
     res.success = false;
+
+    // provide caller with failure indication (not very informative yet)
+    std::stringstream message;
+    message << "Reading IO element " << req.address << " failed.";
     res.message = message.str();
     ROS_ERROR_STREAM_NAMED("io.read", res.message);
+
     return true;
   }
 
@@ -145,11 +148,14 @@ bool MotomanIORelay::writeSingleIoCB(
 
   if (!result)
   {
+    res.success = false;
+
+    // provide caller with failure indication (not very informative yet)
     std::stringstream message;
     message << "Writing to IO element " << req.address << " failed";
-    res.success = false;
     res.message = message.str();
     ROS_ERROR_STREAM_NAMED("io.write", res.message);
+
     return true;
   }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -122,12 +122,11 @@ bool MotomanIORelay::readSingleIoCB(
     return true;
   }
 
-  std::stringstream message;
-  message << "Element " << req.address << " value: " << io_val;
+  ROS_DEBUG_STREAM_NAMED("io.read", "Address " << req.address << ", value: " << io_val);
+
+  // no failure, so no need for an additional message
   res.value = io_val;
   res.success = true;
-  res.message = message.str();
-  ROS_DEBUG_NAMED("io.read", message.str().c_str());
   return true;
 }
 
@@ -154,11 +153,10 @@ bool MotomanIORelay::writeSingleIoCB(
     return true;
   }
 
-  std::stringstream message;
-  message << "Element " << req.address << " set to: " << req.value;
+  ROS_DEBUG_STREAM_NAMED("io.write", "Element " << req.address << " set to: " << req.value);
+
+  // no failure, so no need for an additional message
   res.success = true;
-  res.message = message.str();
-  ROS_DEBUG_NAMED("io.write", message.str().c_str());
   return true;
 }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -118,7 +118,7 @@ bool MotomanIORelay::readSingleIoCB(
     message << "Reading IO element " << req.address << " failed";
     res.success = false;
     res.message = message.str();
-    ROS_ERROR_NAMED("io.read", message.str().c_str());
+    ROS_ERROR_STREAM_NAMED("io.read", message.str());
     return true;
   }
 
@@ -150,7 +150,7 @@ bool MotomanIORelay::writeSingleIoCB(
     message << "Writing to IO element " << req.address << " failed";
     res.success = false;
     res.message = message.str();
-    ROS_ERROR_NAMED("io.write",  message.str().c_str());
+    ROS_ERROR_STREAM_NAMED("io.write", message.str());
     return true;
   }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -118,7 +118,7 @@ bool MotomanIORelay::readSingleIoCB(
     message << "Reading IO element " << req.address << " failed";
     res.success = false;
     res.message = message.str();
-    ROS_ERROR_STREAM_NAMED("io.read", message.str());
+    ROS_ERROR_STREAM_NAMED("io.read", res.message);
     return true;
   }
 
@@ -150,7 +150,7 @@ bool MotomanIORelay::writeSingleIoCB(
     message << "Writing to IO element " << req.address << " failed";
     res.success = false;
     res.message = message.str();
-    ROS_ERROR_STREAM_NAMED("io.write", message.str());
+    ROS_ERROR_STREAM_NAMED("io.write", res.message);
     return true;
   }
 

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <limits>
 #include <ros/ros.h>
+#include <sstream>
 
 namespace motoman
 {
@@ -113,12 +114,20 @@ bool MotomanIORelay::readSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR_NAMED("io.read", "Reading IO element %d failed", req.address);
-    return false;
+    std::stringstream message;
+    message << "Reading IO element " << req.address << " failed";
+    res.success = false;
+    res.message = message.str();
+    ROS_ERROR_NAMED("io.read", message.str().c_str());
+    return true;
   }
-  res.value = io_val;
-  ROS_DEBUG_NAMED("io.read", "Element %d value: %d", req.address, io_val);
 
+  std::stringstream message;
+  message << "Element " << req.address << " value: " << io_val;
+  res.value = io_val;
+  res.success = true;
+  res.message = message.str();
+  ROS_DEBUG_NAMED("io.read", message.str().c_str());
   return true;
 }
 
@@ -137,11 +146,19 @@ bool MotomanIORelay::writeSingleIoCB(
 
   if (!result)
   {
-    ROS_ERROR_NAMED("io.write", "Writing IO element %d failed", req.address);
-    return false;
+    std::stringstream message;
+    message << "Writing to IO element " << req.address << " failed";
+    res.success = false;
+    res.message = message.str();
+    ROS_ERROR_NAMED("io.write",  message.str().c_str());
+    return true;
   }
-  ROS_DEBUG_NAMED("io.write", "Element %d set to: %d", req.address, req.value);
 
+  std::stringstream message;
+  message << "Element " << req.address << " set to: " << req.value;
+  res.success = true;
+  res.message = message.str();
+  ROS_DEBUG_NAMED("io.write", message.str().c_str());
   return true;
 }
 

--- a/motoman_msgs/srv/ReadSingleIO.srv
+++ b/motoman_msgs/srv/ReadSingleIO.srv
@@ -12,4 +12,6 @@
 
 uint32 address
 ---
+bool success
 int32 value
+string message

--- a/motoman_msgs/srv/ReadSingleIO.srv
+++ b/motoman_msgs/srv/ReadSingleIO.srv
@@ -12,6 +12,6 @@
 
 uint32 address
 ---
+string message
 bool success
 int32 value
-string message

--- a/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman_msgs/srv/WriteSingleIO.srv
@@ -17,3 +17,5 @@
 uint32 address
 int32 value
 ---
+bool success
+string message

--- a/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman_msgs/srv/WriteSingleIO.srv
@@ -17,5 +17,5 @@
 uint32 address
 int32 value
 ---
-bool success
 string message
+bool success


### PR DESCRIPTION
This pull request addresses issue ros-industrial#362, adding success and message fields to the Motoman IO services