### PR TITLE
Forward MotoROS (1.9.2+) IO service results to ROS clients

### DIFF
--- a/motoman_driver/CMakeLists.txt
+++ b/motoman_driver/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(motoman_driver)
 
+# require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Load catkin and all dependencies required for this package
 find_package(
   catkin

--- a/motoman_driver/include/motoman_driver/io_ctrl.h
+++ b/motoman_driver/include/motoman_driver/io_ctrl.h
@@ -70,20 +70,22 @@ public:
    *
    * \param address The address (index) of the IO point
    * \param value [out] Will contain the value of the IO point
+   * \param err_msg [out] A descriptive error message in case of failure
    * \return True IFF reading was successful
    */
   bool readSingleIO(industrial::shared_types::shared_int address,
-    industrial::shared_types::shared_int &value);
+    industrial::shared_types::shared_int &value, std::string& err_msg);
 
   /**
    * \brief Writes to a single IO point on the controller.
    *
    * \param address The address (index) of the IO point
    * \param value The value to set the IO element to
+   * \param err_msg [out] A descriptive error message in case of failure
    * \return True IFF writing was successful
    */
   bool writeSingleIO(industrial::shared_types::shared_int address,
-    industrial::shared_types::shared_int value);
+    industrial::shared_types::shared_int value, std::string& err_msg);
 
 protected:
   SmplMsgConnection* connection_;

--- a/motoman_driver/include/motoman_driver/simple_message/motoman_read_single_io_reply.h
+++ b/motoman_driver/include/motoman_driver/simple_message/motoman_read_single_io_reply.h
@@ -57,15 +57,15 @@ namespace io_ctrl_reply
 /**
  * \brief Enumeration of Read Single IO reply result codes.
  */
-namespace ReadSingleIOReplyResults
+namespace ReadSingleIOReplyResultCodes
 {
-enum ReadSingleIOReplyResult
+enum ReadSingleIOReplyResultCode
 {
   FAILURE    = 0,
   SUCCESS    = 1
 };
 }
-typedef ReadSingleIOReplyResults::ReadSingleIOReplyResult ReadSingleIOReplyResult;
+typedef ReadSingleIOReplyResultCodes::ReadSingleIOReplyResultCode ReadSingleIOReplyResultCode;
 
 /**
  * \brief Class encapsulated read single io reply data.  These messages are sent
@@ -111,7 +111,7 @@ public:
    *
    */
   void init(industrial::shared_types::shared_int value,
-            ReadSingleIOReplyResult result_code);
+            ReadSingleIOReplyResultCode result_code);
 
   /**
    * \brief Sets value

--- a/motoman_driver/include/motoman_driver/simple_message/motoman_read_single_io_reply.h
+++ b/motoman_driver/include/motoman_driver/simple_message/motoman_read_single_io_reply.h
@@ -61,8 +61,12 @@ namespace ReadSingleIOReplyResultCodes
 {
 enum ReadSingleIOReplyResultCode
 {
-  FAILURE    = 0,
-  SUCCESS    = 1
+  SUCCESS               =    0,
+  READ_ADDRESS_INVALID  = 1001, // The ioAddress cannot be read on this controller
+  WRITE_ADDRESS_INVALID = 1002, // The ioAddress cannot be written to on this controller
+  WRITE_VALUE_INVALID   = 1003, // The value supplied is not a valid value for the addressed IO element
+  READ_API_ERROR        = 1004, // mpReadIO returned -1
+  WRITE_API_ERROR       = 1005, // mpWriteIO returned -1
 };
 }
 typedef ReadSingleIOReplyResultCodes::ReadSingleIOReplyResultCode ReadSingleIOReplyResultCode;

--- a/motoman_driver/include/motoman_driver/simple_message/motoman_write_single_io_reply.h
+++ b/motoman_driver/include/motoman_driver/simple_message/motoman_write_single_io_reply.h
@@ -61,8 +61,12 @@ namespace WriteSingleIOReplyResultCodes
 {
 enum WriteSingleIOReplyResultCode
 {
-  FAILURE    = 0,
-  SUCCESS    = 1
+  SUCCESS               =    0,
+  READ_ADDRESS_INVALID  = 1001, // The ioAddress cannot be read on this controller
+  WRITE_ADDRESS_INVALID = 1002, // The ioAddress cannot be written to on this controller
+  WRITE_VALUE_INVALID   = 1003, // The value supplied is not a valid value for the addressed IO element
+  READ_API_ERROR        = 1004, // mpReadIO returned -1
+  WRITE_API_ERROR       = 1005, // mpWriteIO returned -1
 };
 }
 typedef WriteSingleIOReplyResultCodes::WriteSingleIOReplyResultCode WriteSingleIOReplyResultCode;

--- a/motoman_driver/include/motoman_driver/simple_message/motoman_write_single_io_reply.h
+++ b/motoman_driver/include/motoman_driver/simple_message/motoman_write_single_io_reply.h
@@ -57,15 +57,15 @@ namespace io_ctrl_reply
 /**
  * \brief Enumeration of Write Single IO reply result codes.
  */
-namespace WriteSingleIOReplyResults
+namespace WriteSingleIOReplyResultCodes
 {
-enum WriteSingleIOReplyResult
+enum WriteSingleIOReplyResultCode
 {
   FAILURE    = 0,
   SUCCESS    = 1
 };
 }
-typedef WriteSingleIOReplyResults::WriteSingleIOReplyResult WriteSingleIOReplyResult;
+typedef WriteSingleIOReplyResultCodes::WriteSingleIOReplyResultCode WriteSingleIOReplyResultCode;
 
 /**
  * \brief Class encapsulated write single io reply data.  These messages are sent
@@ -109,7 +109,7 @@ public:
    * \brief Initializes a complete read single io reply
    *
    */
-  void init(WriteSingleIOReplyResult result_code);
+  void init(WriteSingleIOReplyResultCode result_code);
 
   /**
    * \brief Sets the result code

--- a/motoman_driver/src/io_ctrl.cpp
+++ b/motoman_driver/src/io_ctrl.cpp
@@ -65,7 +65,7 @@ bool MotomanIoCtrl::init(SmplMsgConnection* connection)
   return true;
 }
 
-bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value)
+bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value, std::string &err_msg)
 {
   ReadSingleIOReply reply;
 
@@ -78,11 +78,15 @@ bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value)
   value = reply.getValue();
 
   bool read_success = reply.getResultCode() == ReadSingleIOReplyResultCodes::SUCCESS;
+  if (!read_success)
+  {
+    err_msg = reply.getResultString();
+  }
 
   return read_success;
 }
 
-bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
+bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value, std::string &err_msg)
 {
   WriteSingleIOReply reply;
 
@@ -93,6 +97,10 @@ bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
   }
 
   bool write_success = reply.getResultCode() == WriteSingleIOReplyResultCodes::SUCCESS;
+  if (!write_success)
+  {
+    err_msg = reply.getResultString();
+  }
 
   return write_success;
 }

--- a/motoman_driver/src/io_ctrl.cpp
+++ b/motoman_driver/src/io_ctrl.cpp
@@ -41,8 +41,8 @@
 #include <string>
 
 
-namespace ReadSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResults;
-namespace WriteSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResults;
+namespace ReadSingleIOReplyResultCodes = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResultCodes;
+namespace WriteSingleIOReplyResultCodes = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResultCodes;
 
 using motoman::simple_message::io_ctrl::ReadSingleIO;
 using motoman::simple_message::io_ctrl_message::ReadSingleIOMessage;
@@ -77,7 +77,9 @@ bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value)
 
   value = reply.getValue();
 
-  return (reply.getResultCode() == ReadSingleIOReplyResults::SUCCESS);
+  bool read_success = reply.getResultCode() == ReadSingleIOReplyResultCodes::SUCCESS;
+
+  return read_success;
 }
 
 bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
@@ -90,7 +92,9 @@ bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
     return false;
   }
 
-  return (reply.getResultCode() == WriteSingleIOReplyResults::SUCCESS);
+  bool write_success = reply.getResultCode() == WriteSingleIOReplyResultCodes::SUCCESS;
+
+  return write_success;
 }
 
 bool MotomanIoCtrl::sendAndReceive(shared_int address, ReadSingleIOReply &reply)

--- a/motoman_driver/src/io_relay.cpp
+++ b/motoman_driver/src/io_relay.cpp
@@ -106,19 +106,21 @@ bool MotomanIORelay::readSingleIoCB(
   motoman_msgs::ReadSingleIO::Response &res)
 {
   shared_int io_val= -1;
+  std::string err_msg;
 
   // send message and release mutex as soon as possible
   this->mutex_.lock();
-  bool result = io_ctrl_.readSingleIO(req.address, io_val);
+  bool result = io_ctrl_.readSingleIO(req.address, io_val, err_msg);
   this->mutex_.unlock();
 
   if (!result)
   {
     res.success = false;
 
-    // provide caller with failure indication (not very informative yet)
+    // provide caller with failure indication
+    // TODO: should we also return the result code?
     std::stringstream message;
-    message << "Reading IO element " << req.address << " failed.";
+    message << "Read failed (address: " << req.address << "): " << err_msg;
     res.message = message.str();
     ROS_ERROR_STREAM_NAMED("io.read", res.message);
 
@@ -140,19 +142,21 @@ bool MotomanIORelay::writeSingleIoCB(
   motoman_msgs::WriteSingleIO::Response &res)
 {
   shared_int io_val= -1;
+  std::string err_msg;
 
   // send message and release mutex as soon as possible
   this->mutex_.lock();
-  bool result = io_ctrl_.writeSingleIO(req.address, req.value);
+  bool result = io_ctrl_.writeSingleIO(req.address, req.value, err_msg);
   this->mutex_.unlock();
 
   if (!result)
   {
     res.success = false;
 
-    // provide caller with failure indication (not very informative yet)
+    // provide caller with failure indication
+    // TODO: should we also return the result code?
     std::stringstream message;
-    message << "Writing to IO element " << req.address << " failed";
+    message << "Write failed (address: " << req.address << "): " << err_msg;
     res.message = message.str();
     ROS_ERROR_STREAM_NAMED("io.write", res.message);
 

--- a/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
@@ -47,7 +47,7 @@
 #endif
 
 using industrial::shared_types::shared_int;
-namespace ReadSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResults;
+namespace ReadSingleIOReplyResultCodes = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResultCodes;
 
 namespace motoman
 {
@@ -67,10 +67,10 @@ ReadSingleIOReply::~ReadSingleIOReply(void)
 void ReadSingleIOReply::init()
 {
   // TODO: is '0' a good initial value?
-  this->init(0/*value*/, ReadSingleIOReplyResults::SUCCESS);
+  this->init(0/*value*/, ReadSingleIOReplyResultCodes::SUCCESS);
 }
 
-void ReadSingleIOReply::init(shared_int value, ReadSingleIOReplyResult result_code)
+void ReadSingleIOReply::init(shared_int value, ReadSingleIOReplyResultCode result_code)
 {
   this->setValue(value);
   this->setResultCode(result_code);
@@ -80,9 +80,9 @@ std::string ReadSingleIOReply::getResultString(shared_int result_code)
 {
   switch (result_code)
   {
-  case ReadSingleIOReplyResults::FAILURE:
+  case ReadSingleIOReplyResultCodes::FAILURE:
     return "Failed";
-  case ReadSingleIOReplyResults::SUCCESS:
+  case ReadSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:
     return "Unknown";

--- a/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
@@ -80,8 +80,16 @@ std::string ReadSingleIOReply::getResultString(shared_int result_code)
 {
   switch (result_code)
   {
-  case ReadSingleIOReplyResultCodes::FAILURE:
-    return "Failed";
+  case ReadSingleIOReplyResultCodes::READ_ADDRESS_INVALID:
+     return "Illegal address for read: outside permitted range on this controller, see documentation (1001)";
+  case ReadSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID:
+     return "Illegal address for write: outside permitted range on this controller, see documentation (1002)";
+  case ReadSingleIOReplyResultCodes::WRITE_VALUE_INVALID:
+     return "Illegal value for the type of IO element addressed (1003)";
+  case ReadSingleIOReplyResultCodes::READ_API_ERROR:
+     return "The MotoPlus function MpReadIO returned -1. No further information is available (1004)";
+  case ReadSingleIOReplyResultCodes::WRITE_API_ERROR:
+     return "The MotoPlus function MpWriteIO returned -1. No further information is available (1005)";
   case ReadSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:

--- a/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_read_single_io_reply.cpp
@@ -81,15 +81,20 @@ std::string ReadSingleIOReply::getResultString(shared_int result_code)
   switch (result_code)
   {
   case ReadSingleIOReplyResultCodes::READ_ADDRESS_INVALID:
-     return "Illegal address for read: outside permitted range on this controller, see documentation (1001)";
+     return "Illegal address for read: outside permitted range on this controller, "
+            "see documentation (" + std::to_string(ReadSingleIOReplyResultCodes::READ_ADDRESS_INVALID) + ")";
   case ReadSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID:
-     return "Illegal address for write: outside permitted range on this controller, see documentation (1002)";
+     return "Illegal address for write: outside permitted range on this controller, "
+            "see documentation (" + std::to_string(ReadSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID) + ")";
   case ReadSingleIOReplyResultCodes::WRITE_VALUE_INVALID:
-     return "Illegal value for the type of IO element addressed (1003)";
+     return "Illegal value for the type of IO element addressed "
+            "(" + std::to_string(ReadSingleIOReplyResultCodes::WRITE_VALUE_INVALID) + ")";
   case ReadSingleIOReplyResultCodes::READ_API_ERROR:
-     return "The MotoPlus function MpReadIO returned -1. No further information is available (1004)";
+     return "The MotoPlus function MpReadIO returned -1. No further information is available "
+            "(" + std::to_string(ReadSingleIOReplyResultCodes::READ_API_ERROR) + ")";
   case ReadSingleIOReplyResultCodes::WRITE_API_ERROR:
-     return "The MotoPlus function MpWriteIO returned -1. No further information is available (1005)";
+     return "The MotoPlus function MpWriteIO returned -1. No further information is available ";
+            "(" + std::to_string(ReadSingleIOReplyResultCodes::WRITE_API_ERROR) + ")";
   case ReadSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:

--- a/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
@@ -80,15 +80,20 @@ std::string WriteSingleIOReply::getResultString(shared_int result_code)
   switch (result_code)
   {
   case WriteSingleIOReplyResultCodes::READ_ADDRESS_INVALID:
-     return "Illegal address for read: outside permitted range on this controller, see documentation (1001)";
+     return "Illegal address for read: outside permitted range on this controller, "
+            "see documentation (" + std::to_string(WriteSingleIOReplyResultCodes::READ_ADDRESS_INVALID) + ")";
   case WriteSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID:
-     return "Illegal address for write: outside permitted range on this controller, see documentation (1002)";
+     return "Illegal address for write: outside permitted range on this controller, "
+            "see documentation (" + std::to_string(WriteSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID) + ")";
   case WriteSingleIOReplyResultCodes::WRITE_VALUE_INVALID:
-     return "Illegal value for the type of IO element addressed (1003)";
+     return "Illegal value for the type of IO element addressed "
+            "(" + std::to_string(WriteSingleIOReplyResultCodes::WRITE_VALUE_INVALID) + ")";
   case WriteSingleIOReplyResultCodes::READ_API_ERROR:
-     return "The MotoPlus function MpReadIO returned -1. No further information is available (1004)";
+     return "The MotoPlus function MpReadIO returned -1. No further information is available "
+            "(" + std::to_string(WriteSingleIOReplyResultCodes::READ_API_ERROR) + ")";
   case WriteSingleIOReplyResultCodes::WRITE_API_ERROR:
-     return "The MotoPlus function MpWriteIO returned -1. No further information is available (1005)";
+     return "The MotoPlus function MpWriteIO returned -1. No further information is available ";
+            "(" + std::to_string(WriteSingleIOReplyResultCodes::WRITE_API_ERROR) + ")";
   case WriteSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:

--- a/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
@@ -79,8 +79,16 @@ std::string WriteSingleIOReply::getResultString(shared_int result_code)
 {
   switch (result_code)
   {
-  case WriteSingleIOReplyResultCodes::FAILURE:
-    return "Failed";
+  case WriteSingleIOReplyResultCodes::READ_ADDRESS_INVALID:
+     return "Illegal address for read: outside permitted range on this controller, see documentation (1001)";
+  case WriteSingleIOReplyResultCodes::WRITE_ADDRESS_INVALID:
+     return "Illegal address for write: outside permitted range on this controller, see documentation (1002)";
+  case WriteSingleIOReplyResultCodes::WRITE_VALUE_INVALID:
+     return "Illegal value for the type of IO element addressed (1003)";
+  case WriteSingleIOReplyResultCodes::READ_API_ERROR:
+     return "The MotoPlus function MpReadIO returned -1. No further information is available (1004)";
+  case WriteSingleIOReplyResultCodes::WRITE_API_ERROR:
+     return "The MotoPlus function MpWriteIO returned -1. No further information is available (1005)";
   case WriteSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:

--- a/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_write_single_io_reply.cpp
@@ -47,7 +47,7 @@
 #endif
 
 using industrial::shared_types::shared_int;
-namespace WriteSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResults;
+namespace WriteSingleIOReplyResultCodes = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResultCodes;
 
 namespace motoman
 {
@@ -67,10 +67,10 @@ WriteSingleIOReply::~WriteSingleIOReply(void)
 void WriteSingleIOReply::init()
 {
   // TODO: is success a good initial value?
-  this->init(WriteSingleIOReplyResults::SUCCESS);
+  this->init(WriteSingleIOReplyResultCodes::SUCCESS);
 }
 
-void WriteSingleIOReply::init(WriteSingleIOReplyResult result_code)
+void WriteSingleIOReply::init(WriteSingleIOReplyResultCode result_code)
 {
   this->setResultCode(result_code);
 }
@@ -79,9 +79,9 @@ std::string WriteSingleIOReply::getResultString(shared_int result_code)
 {
   switch (result_code)
   {
-  case WriteSingleIOReplyResults::FAILURE:
+  case WriteSingleIOReplyResultCodes::FAILURE:
     return "Failed";
-  case WriteSingleIOReplyResults::SUCCESS:
+  case WriteSingleIOReplyResultCodes::SUCCESS:
     return "Success";
   default:
     return "Unknown";


### PR DESCRIPTION
This PR uses the updated `result_code` values added in #369 (which hasn't been merged yet) to provide ROS service clients with more descriptive error messages in case something goes wrong.

Examples of messages returned:

```shell
$ rosservice call /read_single_io "address: 10018"
message: "Read failed (address: 10018): Illegal address for read: outside permitted range on this controller, see documentation (1001)"
success: False
value: 0

$ rosservice call /write_single_io "{ address: 0, value: 0 }"
message: "Write failed (address: 0): Illegal address for write: outside permitted range on this controller, see documentation (1002)"
success: False

$ rosservice call /write_single_io "{ address: 10010, value: 2 }"
message: "Write failed (address: 10010): Illegal value for the type of IO element addressed (1003)"
success: False
```

Failed `mpReadIO` and `mpWriteIO` have similar messages, but I can't seem to trigger those :)

--

Forgot to mention I believe this would address / fix #367.
