### PR TITLE
rebased 319: serialise SmplMsg connection access in MJTS

### DIFF
--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -32,6 +32,7 @@
 #ifndef MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 #define MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 
+#include <boost/thread/mutex.hpp>
 #include <map>
 #include <string>
 #include <vector>
@@ -132,6 +133,9 @@ public:
 protected:
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;
+
+  // NOTE: make sure the access to SmplMsgConnection is atomic
+  boost::mutex connection_mutex_;
 
   std::map<int, MotomanMotionCtrl> motion_ctrl_map_;
 

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -32,7 +32,7 @@
 #ifndef MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 #define MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 #include <map>
 #include <string>
 #include <vector>
@@ -134,8 +134,11 @@ protected:
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;
 
-  // NOTE: make sure the access to SmplMsgConnection is atomic
-  boost::mutex connection_mutex_;
+  // used to enforce serialisation of all access to the single, shared SmplMsgConnection.
+  // The MotomanMotionCtrl instances can access the shared SmplMsgConnection
+  // concurrently, and SimpleMessage is not thread-safe, so we enforce here in
+  // in this class.
+  std::mutex smpl_msg_conx_mutex_;
 
   std::map<int, MotomanMotionCtrl> motion_ctrl_map_;
 

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -32,7 +32,8 @@
 #ifndef MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 #define MOTOMAN_DRIVER_JOINT_TRAJECTORY_STREAMER_H
 
-#include <mutex>
+#include <mutex>  // NOLINT(build/c++11): Google doesn't approve of mutex
+                  // see https://github.com/google/styleguide/issues/194
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
As per subject.

Commit provenance retained.

Rebased to run with new CI, and added an additional commit which uses C++11 `mutex` instead of Boost.
