### PR TITLE
es_support: bump minimum CMake version

### DIFF
--- a/motoman_es_support/CMakeLists.txt
+++ b/motoman_es_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(motoman_es_support)
 


### PR DESCRIPTION
Was already done in #429, but this package was contributed before that PR.
