### PR TITLE
Add opw parameters for MH12

### DIFF
--- a/motoman_mh12_support/config/opw_parameters_mh12.yaml
+++ b/motoman_mh12_support/config/opw_parameters_mh12.yaml
@@ -1,0 +1,20 @@
+#
+# Parameters for use with IK solvers which support OPW (Ortho-Parallel Wrist)
+# kinematic configurations, as described in the paper "An Analytical Solution
+# of the Inverse Kinematics Problem of Industrial Serial Manipulators with an
+# Ortho-parallel Basis and a Spherical Wrist" by Mathias Brandstötter, Arthur
+# Angerer, and Michael Hofbaur (Proceedings of the Austrian Robotics Workshop
+# 2014, 22-23 May, 2014, Linz, Austria).
+#
+# The moveit_opw_kinematics_plugin package provides such a solver.
+#
+opw_kinematics_geometric_parameters:
+    a1:  0.155
+    a2:  -0.200
+    b:   0.000
+    c1:  0.450
+    c2:  0.614
+    c3:  0.640
+    c4:  0.100
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
+opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]


### PR DESCRIPTION
This adds OPW parameters for the OPW inverse kinematics solver as used by https://github.com/JeroenDM/moveit_opw_kinematics_plugin and others

Parameters were verified against the URDF using the self-verification mechanism of above plugin