### PR TITLE
driver: add missing MotionReply sub codes

### DIFF
--- a/motoman_driver/include/motoman_driver/simple_message/motoman_motion_reply.h
+++ b/motoman_driver/include/motoman_driver/simple_message/motoman_motion_reply.h
@@ -93,7 +93,9 @@ enum InvalidCode
   DATA_POSITION,
   DATA_SPEED,
   DATA_ACCEL,
-  DATA_INSUFFICIENT
+  DATA_INSUFFICIENT,
+  DATA_TIME,
+  DATA_TOOLNO
 };
 }  // namespace Invalid
 
@@ -111,7 +113,9 @@ enum NotReadyCode
   HOLD,
   NOT_STARTED,
   WAITING_ROS,
-  SKILLSEND
+  SKILLSEND,
+  PFL_ACTIVE,
+  INC_MOVE_ERROR
 };
 }  // namespace NotReady
 }  // namespace MotionReplySubcodes

--- a/motoman_driver/src/simple_message/motoman_motion_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_motion_reply.cpp
@@ -162,7 +162,9 @@ std::string MotionReply::getSubcodeString(shared_int code)
   case MotionReplySubcodes::NotReady::SKILLSEND:
     return "Waiting on SkillSend";
   case MotionReplySubcodes::NotReady::PFL_ACTIVE:
-    return "PFL is active";
+    return "Power and Force Limiting (PFL) was activated: "
+      "please reset PFL on the robot, re-enable the driver (call the service) "
+      "and send a new trajectory";
   case MotionReplySubcodes::NotReady::INC_MOVE_ERROR:
     return "Incremental move rejected on MotoROS side";
 

--- a/motoman_driver/src/simple_message/motoman_motion_reply.cpp
+++ b/motoman_driver/src/simple_message/motoman_motion_reply.cpp
@@ -134,6 +134,10 @@ std::string MotionReply::getSubcodeString(shared_int code)
     return "Invalid acceleration data";
   case MotionReplySubcodes::Invalid::DATA_INSUFFICIENT:
     return "Insufficient trajectory data.  Must supply valid time, pos, and velocity fields.";
+  case MotionReplySubcodes::Invalid::DATA_TIME:
+    return "Invalid time data: exceeded maximum trajectory duration of 14400 sec (ros-industrial/motoman#244)";
+  case MotionReplySubcodes::Invalid::DATA_TOOLNO:
+    return "Invalid tool file specified";
 
   case MotionReplySubcodes::NotReady::UNSPECIFIED:
     return "Unknown";
@@ -157,6 +161,10 @@ std::string MotionReply::getSubcodeString(shared_int code)
     return "Waiting on ROS";
   case MotionReplySubcodes::NotReady::SKILLSEND:
     return "Waiting on SkillSend";
+  case MotionReplySubcodes::NotReady::PFL_ACTIVE:
+    return "PFL is active";
+  case MotionReplySubcodes::NotReady::INC_MOVE_ERROR:
+    return "Incremental move rejected on MotoROS side";
 
   default:
     return "Unknown";


### PR DESCRIPTION
As per subject.

Noticed they were missing while working on #435 and #436.

This will only improve the "human side" of `motoman_driver`. The error (sub) codes were processed correctly before this PR, but the human readable error message just converted them to "unknown" errors.
