### PR TITLE
Remove incorrect deprecation warnings from SIA support packages

### DIFF
--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -50,10 +50,5 @@
 
   <export>
     <architecture_independent/>
-    <deprecated>
-      This package will be removed in ROS Kinetic. The configuration data and
-      models included in this package can now be found in the motoman_sia_support
-      package in ROS Jade.
-    </deprecated>
   </export>
 </package>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -50,10 +50,5 @@
 
   <export>
     <architecture_independent/>
-    <deprecated>
-      This package will be removed in ROS Kinetic. The configuration data and
-      models included in this package can now be found in the motoman_sia_support
-      package in ROS Jade.
-    </deprecated>
   </export>
 </package>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -50,10 +50,5 @@
 
   <export>
     <architecture_independent/>
-    <deprecated>
-      This package will be removed in ROS Kinetic. The configuration data and
-      models included in this package can now be found in the motoman_sia_support
-      package in ROS Jade.
-    </deprecated>
   </export>
 </package>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -50,10 +50,5 @@
 
   <export>
     <architecture_independent/>
-    <deprecated>
-      This package will be removed in ROS Kinetic. The configuration data and
-      models included in this package can now be found in the motoman_sia_support
-      package in ROS Jade.
-    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
Quite some time ago already we had the idea to introduce a single `motoman_sia_support` package.

The existing `motoman_siaX(d|f)_support` packages were marked as *deprecated* in preparation.

It's very unlikely we'll introduce `motoman_sia_support` after all, so to stop annoying users, remove the `deprecation` elements from the manifests.

No functional changes.

---

Edit: this would fix #261.

And also closes #117.
