### PR TITLE
sia30: use materials from resources package

### DIFF
--- a/motoman_sia30d_support/package.xml
+++ b/motoman_sia30d_support/package.xml
@@ -43,6 +43,7 @@
 
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/motoman_sia30d_support/urdf/sia30d_macro.xacro
+++ b/motoman_sia30d_support/urdf/sia30d_macro.xacro
@@ -1,22 +1,15 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="motoman_sia30d" params="prefix">
+    <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
 
-    <!-- Properties -->
-    <material name="yaskawa_blue">
-      <color rgba="0.12941 0.14902 0.74902 1" />
-    </material>
-      <material name="silver">
-      <color rgba="0.8 0.8 0.8 1"/>
-    </material>
-    
     <!-- link list -->
     <link name="${prefix}base_link">
       <visual>
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/base_link.stl"/>
         </geometry>
-        <material name="yaskawa_blue"/>
+        <xacro:material_yaskawa_blue/>
       </visual>
       <collision>
         <geometry>
@@ -29,7 +22,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_1_s.stl"/>
         </geometry>
-        <material name="silver"/>
+        <xacro:material_yaskawa_silver/>
       </visual>
       <collision>
         <geometry>
@@ -42,7 +35,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_2_l.stl"/>
         </geometry>
-        <material name="yaskawa_blue"/>
+        <xacro:material_yaskawa_blue/>
       </visual>
       <collision>
         <geometry>
@@ -55,7 +48,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_3_e.stl"/>
         </geometry>
-        <material name="silver"/>
+        <xacro:material_yaskawa_silver/>
       </visual>
       <collision>
         <geometry>
@@ -68,7 +61,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_4_u.stl"/>
         </geometry>
-        <material name="yaskawa_blue"/>
+        <xacro:material_yaskawa_blue/>
       </visual>
       <collision>
         <geometry>
@@ -81,7 +74,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_5_r.stl"/>
         </geometry>
-        <material name="silver"/>
+        <xacro:material_yaskawa_silver/>
       </visual>
       <collision>
         <geometry>
@@ -94,7 +87,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_6_b.stl"/>
         </geometry>
-        <material name="yaskawa_blue"/>
+        <xacro:material_yaskawa_blue/>
       </visual>
       <collision>
         <geometry>
@@ -107,7 +100,7 @@
         <geometry>
           <mesh filename="package://motoman_sia30d_support/meshes/visual/link_7_t.stl"/>
         </geometry>
-        <material name="silver"/>
+        <xacro:material_yaskawa_silver/>
       </visual>
       <collision>
         <geometry>


### PR DESCRIPTION
As per subject.

#411 was submitted before `motoman_resources` was created, so it didn't yet use the `material` definitions from  that package.

No functional changes.
