### PR TITLE
Add MH110 support (predecessor of GP110 with DX200 controller)

### DIFF
--- a/motoman_mh110_support/CMakeLists.txt
+++ b/motoman_mh110_support/CMakeLists.txt
@@ -8,7 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(test/launch_test.xml)
+  roslaunch_add_file_check(test/launch_test_mh110.xml)
 endif()
 
 install(DIRECTORY config launch urdf

--- a/motoman_mh110_support/CMakeLists.txt
+++ b/motoman_mh110_support/CMakeLists.txt
@@ -11,5 +11,5 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/launch_test.xml)
 endif()
 
-install(DIRECTORY config launch meshes urdf
+install(DIRECTORY config launch urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_mh110_support/CMakeLists.txt
+++ b/motoman_mh110_support/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+project(motoman_mh110_support)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/launch_test.xml)
+endif()
+
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/motoman_mh110_support/config/joint_names_mh110.yaml
+++ b/motoman_mh110_support/config/joint_names_mh110.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['joint_1_s', 'joint_2_l', 'joint_3_u', 'joint_4_r', 'joint_5_b', 'joint_6_t']

--- a/motoman_mh110_support/config/opw_parameters_mh110.yaml
+++ b/motoman_mh110_support/config/opw_parameters_mh110.yaml
@@ -1,0 +1,20 @@
+#
+# Parameters for use with IK solvers which support OPW (Ortho-Parallel Wrist)
+# kinematic configurations, as described in the paper "An Analytical Solution
+# of the Inverse Kinematics Problem of Industrial Serial Manipulators with an
+# Ortho-parallel Basis and a Spherical Wrist" by Mathias Brandstötter, Arthur
+# Angerer, and Michael Hofbaur (Proceedings of the Austrian Robotics Workshop
+# 2014, 22-23 May, 2014, Linz, Austria).
+#
+# The moveit_opw_kinematics_plugin package provides such a solver.
+#
+opw_kinematics_geometric_parameters:
+    a1:  0.320
+    a2:  -0.235
+    b:   0.000
+    c1:  0.540
+    c2:  0.870
+    c3:  1.020
+    c4:  0.200
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
+opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mh110_support/launch/load_mh110.launch
+++ b/motoman_mh110_support/launch/load_mh110.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh110_support)/urdf/mh110.xacro'" />
+</launch>

--- a/motoman_mh110_support/launch/robot_interface_streaming_mh110.launch
+++ b/motoman_mh110_support/launch/robot_interface_streaming_mh110.launch
@@ -1,0 +1,19 @@
+<!--
+  Manipulator specific version of 'robot_interface_streaming.launch'.
+  Defaults provided for mh110:
+   - joints
+  Usage:
+    robot_interface_streaming_mh110.launch robot_ip:=<value> controller:=<dx200>
+-->
+<launch>
+  <arg name="robot_ip" />
+
+  <!-- controller: Controller name (dx200) -->
+  <arg name="controller" />
+
+  <rosparam command="load" file="$(find motoman_mh110_support)/config/joint_names_mh110.yaml" />
+
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+</launch>

--- a/motoman_mh110_support/launch/robot_state_visualize_mh110.launch
+++ b/motoman_mh110_support/launch/robot_state_visualize_mh110.launch
@@ -1,0 +1,25 @@
+<!--
+  Manipulator specific version of the state visualizer.
+  Defaults provided for mh110:
+   - joints
+  Usage:
+    robot_state_visualize_mh110.launch robot_ip:=<value> controller:=<dx200>
+-->
+<launch>
+  <arg name="robot_ip" />
+
+  <!-- controller: Controller name (dx200) -->
+  <arg name="controller" />
+
+  <rosparam command="load" file="$(find motoman_mh110_support)/config/joint_names_mh110.yaml" />
+
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+  <include file="$(find motoman_mh110_support)/launch/load_mh110.launch" />
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+</launch>

--- a/motoman_mh110_support/launch/test_mh110.launch
+++ b/motoman_mh110_support/launch/test_mh110.launch
@@ -1,0 +1,9 @@
+<launch>
+  <include file="$(find motoman_mh110_support)/launch/load_mh110.launch" />
+
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+</launch>

--- a/motoman_mh110_support/launch/test_mh110.launch
+++ b/motoman_mh110_support/launch/test_mh110.launch
@@ -2,8 +2,6 @@
   <include file="$(find motoman_mh110_support)/launch/load_mh110.launch" />
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh110_support/package.xml
+++ b/motoman_mh110_support/package.xml
@@ -19,8 +19,7 @@
       Visual appearance, joint limits and maximum joint velocities are 
       identical to the successor GP110 model, the only differences being
       joint effort limits and DX200 vs YRC1000 controller connection.
-      Information on the MH110 can be found in <em>HW1482741 (169859-1CD Rev. 2)</em>
-      at the <a href="https://www.motoman.com/en-us/service-training/product-documentation">Yaskawa Motoman product documentation site</a>.
+      Information on the MH110 can be found in <em>HW1482741 (169859-1CD Rev. 2)</em>.
       The GP110 online documentation files (CAD model GP110_SP100_3D.zip and 
       drawing datasheet <em>HW1385705.01</em>) can be found <a href="https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704">here</a>.
     </p>

--- a/motoman_mh110_support/package.xml
+++ b/motoman_mh110_support/package.xml
@@ -19,8 +19,12 @@
       Visual appearance, joint limits and maximum joint velocities are 
       identical to the successor GP110 model, the only differences being
       joint effort limits and DX200 vs YRC1000 controller connection.
+      Information on the MH110 can be found in <em>HW1482741 (169859-1CD Rev. 2)</em>
+      at the <a href="https://www.motoman.com/en-us/service-training/product-documentation">Yaskawa Motoman product documentation site</a>.
       The GP110 online documentation files (CAD model GP110_SP100_3D.zip and 
-      drawing datasheet <em>HW1385705.01</em> can be found <a href="https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704">here</a>).
+      drawing datasheet <em>HW1385705.01</em>) can be found <a href="https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704">here</a>.
+    </p>
+    <p>
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>

--- a/motoman_mh110_support/package.xml
+++ b/motoman_mh110_support/package.xml
@@ -45,7 +45,10 @@
 
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
+
+  <!-- this package reuses the meshes included in motoman_gp110_support -->
   <exec_depend>motoman_gp110_support</exec_depend>
+
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>

--- a/motoman_mh110_support/package.xml
+++ b/motoman_mh110_support/package.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>motoman_mh110_support</name>
+  <version>0.1.0</version>
+  <description>
+    <p>ROS-Industrial support for the Motoman MH110 (and variants).</p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Motoman MH110 series of manipulators.
+    </p>
+    <p>
+      <b>Specifications</b>
+    </p>
+    <ul>
+      <li>MH110 - Default</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information 
+      found in the online documentation files for the mostly identical successor GP110 model from
+      https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704 )
+      All urdfs are based on the default motion and joint velocity limits, 
+      unless noted otherwise.
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+  </description>
+  <author>Christian Juelg</author>
+  <maintainer email="christian.juelg@optonic.com">Christian Juelg (Optonic GmbH)</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <license>BSD</license>
+
+  <url type="website">http://wiki.ros.org/motoman_mh110_support</url>
+  <url type="bugtracker">https://github.com/ros-industrial/motoman/issues</url>
+  <url type="repository">https://github.com/ros-industrial/motoman</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <test_depend>roslaunch</test_depend>
+
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>motoman_gp110_support</exec_depend>
+  <exec_depend>motoman_resources</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
+</package>

--- a/motoman_mh110_support/package.xml
+++ b/motoman_mh110_support/package.xml
@@ -16,9 +16,11 @@
       <li>MH110 - Default</li>
     </ul>
     <p>
-      Joint limits and maximum joint velocities are based on the information 
-      found in the online documentation files for the mostly identical successor GP110 model from
-      https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704 )
+      Visual appearance, joint limits and maximum joint velocities are 
+      identical to the successor GP110 model, the only differences being
+      joint effort limits and DX200 vs YRC1000 controller connection.
+      The GP110 online documentation files (CAD model GP110_SP100_3D.zip and 
+      drawing datasheet <em>HW1385705.01</em> can be found <a href="https://www.yaskawa.eu.com/products/robots/handling-mounting/productdetail/product/gp110_704">here</a>).
       All urdfs are based on the default motion and joint velocity limits, 
       unless noted otherwise.
     </p>

--- a/motoman_mh110_support/test/launch_test.xml
+++ b/motoman_mh110_support/test/launch_test.xml
@@ -1,0 +1,51 @@
+<!--
+  launch_test.xml - ROSlaunch tests
+  Usage Instructions:
+  1. Add the following to your CMakeLists.txt:
+    find_package(roslaunch)
+    roslaunch_add_file_check(test/launch_test.xml)
+  2. Create a test directory under your package
+  3. Add the "launch_text.xml" file and fill out the test below.  Use the
+     following conventions:
+    a. Encapsulate each launch file test in it's own namespace.  By
+       convention the namespace should have the same name as the launch
+       file (minus ".launch" extension)
+    b. Create tests for each possible combination of parameters.  Utilize
+       sub-namespaces under the main namespace.
+  Notes:
+  1. XML extension is used in order to avoid beinging included
+  in roslaunch auto-complete.
+  2. Group tags with namespaces are used to avoid node name collisions when
+  testing multpile launch files
+-->
+<launch>
+  <arg name="req_arg" value="default" />
+  <arg name="controller" value="dx200" />
+
+  <group ns="load_mh110">
+      <include file="$(find motoman_mh110_support)/launch/load_mh110.launch" />
+  </group>
+
+  <group ns="test_mh110">
+      <include file="$(find motoman_mh110_support)/launch/test_mh110.launch" />
+  </group>
+
+  <group ns="robot_interface_streaming_mh110">
+    <group ns="$(arg controller)">
+      <include file="$(find motoman_mh110_support)/launch/robot_interface_streaming_mh110.launch">
+        <arg name="robot_ip" value="$(arg req_arg)" />
+        <arg name="controller" value="$(arg controller)" />
+      </include>
+    </group>
+  </group>
+
+  <group ns="robot_state_visualize_mh110">
+    <group ns="$(arg controller)">
+      <include file="$(find motoman_mh110_support)/launch/robot_state_visualize_mh110.launch">
+        <arg name="robot_ip" value="$(arg req_arg)" />
+        <arg name="controller" value="$(arg controller)" />
+      </include>
+    </group>
+  </group>
+
+</launch>

--- a/motoman_mh110_support/test/launch_test_mh110.xml
+++ b/motoman_mh110_support/test/launch_test_mh110.xml
@@ -1,11 +1,11 @@
 <!--
-  launch_test.xml - ROSlaunch tests
+  launch_test_mh110.xml - ROSlaunch tests
   Usage Instructions:
   1. Add the following to your CMakeLists.txt:
     find_package(roslaunch)
-    roslaunch_add_file_check(test/launch_test.xml)
+    roslaunch_add_file_check(test/launch_test_mh110.xml)
   2. Create a test directory under your package
-  3. Add the "launch_text.xml" file and fill out the test below.  Use the
+  3. Add the "launch_test_mh110.xml" file and fill out the test below.  Use the
      following conventions:
     a. Encapsulate each launch file test in it's own namespace.  By
        convention the namespace should have the same name as the launch

--- a/motoman_mh110_support/urdf/mh110.xacro
+++ b/motoman_mh110_support/urdf/mh110.xacro
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<robot name="motoman_mh110" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find motoman_mh110_support)/urdf/mh110_macro.xacro" />
+  <xacro:motoman_mh110 prefix=""/>
+</robot>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1_s"/>
       <origin xyz="0 0 0.540" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="4596.87" velocity="${radians(140)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="5516.24" velocity="${radians(140)}"/>
     </joint>
     <joint name="${prefix}joint_2_l" type="revolute">
       <parent link="${prefix}link_1_s"/>
       <child link="${prefix}link_2_l"/>
       <origin xyz="0.320 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-90)}" upper="${radians(155)}" effort="11032.48" velocity="${radians(110)}"/>
+      <limit lower="${radians(-90)}" upper="${radians(155)}" effort="11645.40" velocity="${radians(110)}"/>
     </joint>
     <joint name="${prefix}joint_3_u" type="revolute">
       <parent link="${prefix}link_2_l"/>
       <child link="${prefix}link_3_u"/>
       <origin xyz="0 0 0.870" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-80)}" upper="${radians(90)}" effort="5148.49" velocity="${radians(130)}"/>
+      <limit lower="${radians(-80)}" upper="${radians(90)}" effort="4167.83" velocity="${radians(130)}"/>
     </joint>
     <joint name="${prefix}joint_4_r" type="revolute">
       <parent link="${prefix}link_3_u"/>
@@ -131,7 +131,7 @@
       <child link="${prefix}link_5_b"/>
       <origin xyz="1.020 0 0" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-125)}" upper="${radians(125)}" effort="1323.90" velocity="${radians(175)}"/>
+      <limit lower="${radians(-125)}" upper="${radians(125)}" effort="1176.80" velocity="${radians(175)}"/>
     </joint>
     <joint name="${prefix}joint_6_t" type="revolute">
       <parent link="${prefix}link_5_b"/>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -145,7 +145,7 @@
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
-      <origin xyz="0.200 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
+      <origin xyz="0.200 0 0" rpy="0 0 0"/>
       <parent link="${prefix}link_6_t"/>
       <child link="${prefix}flange"/>
     </joint>
@@ -153,7 +153,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -7,6 +7,7 @@
     <link name="${prefix}base_link">
       <visual>
         <geometry>
+          <!-- this package reuses the meshes included in motoman_gp110_support, gp110 and mh110 have identical dimensions -->
           <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/base_link.stl"/>
         </geometry>
         <xacro:material_yaskawa_blue/>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -1,0 +1,169 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="motoman_mh110" params="prefix">
+    <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
+
+    <!-- link list -->
+    <link name="${prefix}base_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/base_link.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/base_link.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_1_s">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_1_s.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_1_s.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_2_l">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_2_l.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_2_l.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_3_u">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_3_u.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_3_u.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_4_r">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_4_r.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_4_r.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_5_b">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_5_b.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_5_b.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_6_t">
+      <visual>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/visual/link_6_t.stl"/>
+        </geometry>
+        <xacro:material_yaskawa_blue/>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://motoman_gp110_support/meshes/gp110/collision/link_6_t.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <!-- end of link list -->
+
+    <!-- joint list -->
+    <joint name="${prefix}joint_1_s" type="revolute">
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link_1_s"/>
+      <origin xyz="0 0 0.540" rpy="0 0 0" />
+      <axis xyz="0 0 1" />
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="4596.87" velocity="${radians(140)}"/>
+    </joint>
+    <joint name="${prefix}joint_2_l" type="revolute">
+      <parent link="${prefix}link_1_s"/>
+      <child link="${prefix}link_2_l"/>
+      <origin xyz="0.320 0 0" rpy="0 0 0" />
+      <axis xyz="0 1 0" />
+      <limit lower="${radians(-90)}" upper="${radians(155)}" effort="11032.48" velocity="${radians(110)}"/>
+    </joint>
+    <joint name="${prefix}joint_3_u" type="revolute">
+      <parent link="${prefix}link_2_l"/>
+      <child link="${prefix}link_3_u"/>
+      <origin xyz="0 0 0.870" rpy="0 0 0" />
+      <axis xyz="0 -1 0" />
+      <limit lower="${radians(-80)}" upper="${radians(90)}" effort="5148.49" velocity="${radians(130)}"/>
+    </joint>
+    <joint name="${prefix}joint_4_r" type="revolute">
+      <parent link="${prefix}link_3_u"/>
+      <child link="${prefix}link_4_r"/>
+      <origin xyz="0 0 0.235" rpy="0 0 0" />
+      <axis xyz="-1 0 0" />
+      <limit lower="${radians(-360)}" upper="${radians(360)}" effort="1200.33" velocity="${radians(175)}"/>
+    </joint>
+    <joint name="${prefix}joint_5_b" type="revolute">
+      <parent link="${prefix}link_4_r"/>
+      <child link="${prefix}link_5_b"/>
+      <origin xyz="1.020 0 0" rpy="0 0 0" />
+      <axis xyz="0 -1 0" />
+      <limit lower="${radians(-125)}" upper="${radians(125)}" effort="1323.90" velocity="${radians(175)}"/>
+    </joint>
+    <joint name="${prefix}joint_6_t" type="revolute">
+      <parent link="${prefix}link_5_b"/>
+      <child link="${prefix}link_6_t"/>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <axis xyz="-1 0 0" />
+      <limit lower="${radians(-360)}" upper="${radians(360)}" effort="823.76" velocity="${radians(255)}"/>
+    </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange"/>
+    <joint name="${prefix}joint_6_t-flange" type="fixed">
+      <origin xyz="0.200 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
+      <parent link="${prefix}link_6_t"/>
+      <child link="${prefix}flange"/>
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0"/>
+    <joint name="${prefix}flange-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}flange"/>
+      <child link="${prefix}tool0"/>
+    </joint>
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
As far as the datasheets tell MH110 and GP110 are identical except for some kg of total weight and DX200 vs YRC1000 controller.

The URDF references the GP110 meshes for the collision models, and package.xml lists motoman_gp110_support as a dependency.

@EricMarcil Could you please check if the joint effort limits are the same for GP110 and MH110? 

I couldn't find any 3D CAD model for the MH110, but it appears to be identical to the GP110.

This MR build upon #476