### PR TITLE
downgrade scary log message to INFO instead, provide default controller TCP port

### DIFF
--- a/motoman_driver/launch/io_relay.launch
+++ b/motoman_driver/launch/io_relay.launch
@@ -13,7 +13,14 @@
 
   <!-- load the correct version of the io relay node -->
   <node if="$(arg use_bswap)" name="io_relay"
-        pkg="motoman_driver" type="io_relay_bswap" />
+        pkg="motoman_driver" type="io_relay_bswap">
+    <!-- set default TCP port for the controller -->
+    <param name="port" value="50242" />
+  </node>
+
   <node unless="$(arg use_bswap)" name="io_relay"
-        pkg="motoman_driver" type="io_relay" />
+        pkg="motoman_driver" type="io_relay">
+    <!-- set default TCP port for the controller -->
+    <param name="port" value="50242" />
+  </node>
 </launch>

--- a/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
+++ b/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
@@ -116,7 +116,7 @@ bool getJointGroups(const std::string topic_param, std::map<int, RobotGroup> & r
   }
   else
   {
-    ROS_ERROR_STREAM("Failed to find " << topic_param << " parameter");
+    ROS_INFO_STREAM("Failed to find " << topic_param << " parameter");
     return false;
   }
 }


### PR DESCRIPTION
The `Failed to find topic_list parameter` error message is too aggressive as this is the normal case when there is just one arm connected.

The `Failed to get '~port' parameter: using default (50242)` warning can be avoided by just adding this default parameter explicitly to io_relay.launch.

Thanks to @gavanderhoorn for your feedback.