### PR TITLE
Driver: add default port for IO server to launch file (alternative to #483)

### DIFF
--- a/motoman_driver/launch/io_relay.launch
+++ b/motoman_driver/launch/io_relay.launch
@@ -5,6 +5,9 @@
   <!-- IP of robot (or PC running simulation) -->
   <arg name="robot_ip" doc="IP of controller" />
 
+  <!-- TCP port the IO server is listening on -->
+  <arg name="tcp_port" default="50242" doc="TCP port the IO server is listening on" />
+
   <!-- Load the byte-swapping version of io_relay if required -->
   <arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
@@ -13,7 +16,12 @@
 
   <!-- load the correct version of the io relay node -->
   <node if="$(arg use_bswap)" name="io_relay"
-        pkg="motoman_driver" type="io_relay_bswap" />
+        pkg="motoman_driver" type="io_relay_bswap">
+    <param name="port" value="$(arg tcp_port)" />
+  </node>
+
   <node unless="$(arg use_bswap)" name="io_relay"
-        pkg="motoman_driver" type="io_relay" />
+        pkg="motoman_driver" type="io_relay">
+    <param name="port" value="$(arg tcp_port)" />
+  </node>
 </launch>


### PR DESCRIPTION
Altered the implementation proposed in #483 slightly to not hard-code the default value, but expose it as a parameter.

This is a slight divergence from the other nodes in `motoman_driver` (as they don't support configurable port numbers), but the `io_relay` is a more recent addition, and does support this.
