### PR TITLE
Improve WARN and INFO msgs when topic_list parameter isn't found

### DIFF
--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -60,7 +60,15 @@ JointTrajectoryAction::JointTrajectoryAction() :
   pn.param("constraints/goal_threshold", goal_threshold_, DEFAULT_GOAL_THRESHOLD_);
 
   std::map<int, RobotGroup> robot_groups;
-  getJointGroups("topic_list", robot_groups);
+  if (!getJointGroups("topic_list", robot_groups))
+  {
+    // this is a WARN as this class is the multi-group version of the regular JTA,
+    // and we're actually expecting to find the 'topic_list' parameter, as using
+    // this multi-group version with a single-group system is unnecessary and also
+    // doesn't make much sense.
+    // It probably also won't work.
+    ROS_WARN("Expecting/assuming single motion-group controller configuration");
+  }
 
   for (size_t i = 0; i < robot_groups.size(); i++)
   {

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -92,6 +92,7 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
   }
   else
   {
+    ROS_INFO("Expecting/assuming single motion-group controller configuration");
     this->version_0_ = true;
     std::vector<std::string> joint_names;
     if (!getJointNames("controller_joint_names", "robot_description", joint_names))

--- a/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
+++ b/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
@@ -116,7 +116,7 @@ bool getJointGroups(const std::string topic_param, std::map<int, RobotGroup> & r
   }
   else
   {
-    ROS_ERROR_STREAM("Failed to find " << topic_param << " parameter");
+    ROS_INFO_STREAM("Failed to find " << topic_param << " parameter");
     return false;
   }
 }

--- a/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
+++ b/motoman_driver/src/industrial_robot_client/motoman_utils.cpp
@@ -116,7 +116,7 @@ bool getJointGroups(const std::string topic_param, std::map<int, RobotGroup> & r
   }
   else
   {
-    ROS_INFO_STREAM("Failed to find " << topic_param << " parameter");
+    ROS_INFO_STREAM("Failed to find '" << topic_param << "' parameter");
     return false;
   }
 }

--- a/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/robot_state_interface.cpp
@@ -92,6 +92,7 @@ bool RobotStateInterface::init(SmplMsgConnection* connection)
   }
   else
   {
+    ROS_INFO("Expecting/assuming single motion-group controller configuration");
     this->version_0_ = true;
     std::vector<std::string> joint_names;
     if (!getJointNames("controller_joint_names", "robot_description", joint_names))


### PR DESCRIPTION
This fixes #113 -- and basically implements the suggestion there.

Original commit proposed by @cjue in #483. The version here is a slightly expanded version.

I also wanted to use separate commits and PRs for this change (and the other change in #483, which is now in #484).

The result of this change is that callers of `getJointGroups(..)` get to decide what to do/print/log when it can't find the `topic_list` parameter: print a warning or do something else.

Example output with these changes:

```
[ INFO] [...] [/joint_state]: Failed to find 'topic_list' parameter
[ INFO] [...] [/joint_state]: Expecting/assuming single motion-group controller configuration
[ INFO] [...] [/joint_state]: Adding joint_1_s to list parameter
[ INFO] [...] [/joint_state]: Adding joint_2_l to list parameter
...
```

As the commit comment explains though: the `WARN` is retained for the case where the multi-group version of the JTA is started, but the multi-group configuration cannot be found. That's still not necessarily an `ERROR`, as that node *can* be used for such cases, but it's definitely abnormal, and warrants a `WARN`.
