### PR TITLE
Alternative implementation of multi-group trajectories and update motoman error handling

### DIFF
--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -47,6 +47,7 @@
 #include <industrial_msgs/RobotStatus.h>
 #include <motoman_driver/industrial_robot_client/robot_group.h>
 #include <motoman_msgs/DynamicJointTrajectory.h>
+#include <motoman_msgs/MotorosError.h>
 namespace industrial_robot_client
 {
 namespace joint_trajectory_action
@@ -108,6 +109,11 @@ private:
    * robot driver).
    */
   ros::Subscriber sub_robot_status_;
+
+  /**
+   * \brief Subscribes to motoros error messages to abort trajectories.
+   */
+  ros::Subscriber sub_motoros_errors_;
 
   /**
    * \brief Watchdog time used to fail the action request if the robot
@@ -225,6 +231,15 @@ private:
    *
    */
   void robotStatusCB(const industrial_msgs::RobotStatusConstPtr &msg);
+
+  /**
+   * \brief Motoross error callback (executed when motoros error
+   * message received)
+   *
+   * \param msg Motoros error message
+   *
+   */
+  void motorosErrorCB(const motoman_msgs::MotorosError &msg);
 
   /**
    * \brief Marks the current action goal as succeeded.

--- a/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
+++ b/motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h
@@ -116,9 +116,10 @@ private:
   ros::Timer watchdog_timer_;
 
   /**
-   * \brief Indicates whether a motion has been started
+   * \brief The time that the active trajectory is expected to end execution.
+   * Used to determine when to begin checking for goal completion.
    */
-  bool motion_started_;
+  ros::Time expected_traj_end_;
 
   /**
    * \brief Indicates action has an active goal

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -132,6 +132,11 @@ public:
 
   virtual void streamingThread();
 
+  /**
+   * \brief Safely disable Yaskawa arm before system shutdown.
+   */
+  void shutdown();
+
 protected:
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;

--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -169,6 +169,12 @@ protected:
   ros::ServiceServer srv_select_tool_;
 
   /**
+   * \brief Publisher to announce motoros failures. This allows higher-level
+   * drivers to retry certain actions.
+   */
+  ros::Publisher motoros_error_pub_;
+
+  /**
    * \brief Disable the robot. Response is true if the state was flipped or
    * false if the state has not changed.
    *

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -84,6 +84,8 @@ JointTrajectoryAction::JointTrajectoryAction() :
 
   sub_robot_status_ = node_.subscribe("robot_status", 1, &JointTrajectoryAction::robotStatusCB, this);
 
+  sub_motoros_errors_ = node_.subscribe("motoros_error", 1, &JointTrajectoryAction::motorosErrorCB, this);
+
   // Set watchdog timer for entire robot state.
   watchdog_timer_ = node_.createTimer(ros::Duration(WATCHDOG_PERIOD_),
                               boost::bind(&JointTrajectoryAction::watchdog, this, _1));
@@ -444,6 +446,17 @@ void JointTrajectoryAction::controllerStateCB(
   else if (last_robot_status_->in_motion.val == industrial_msgs::TriState::FALSE)
   {
     ROS_WARN("Outside goal constraints, aborting trajectory");
+    abortGoal();
+  }
+}
+
+void JointTrajectoryAction::motorosErrorCB(const motoman_msgs::MotorosError &msg)
+{
+  ROS_WARN_STREAM(
+    "Encountered motoros error " << msg.code << "-" << msg.subcode << ": "
+    << msg.code_description << " " << msg.subcode_description);
+  if (has_active_goal_)
+  {
     abortGoal();
   }
 }

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -38,6 +38,7 @@
 #include <industrial_utils/utils.h>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 using industrial_robot_client::motoman_utils::getJointGroups;
@@ -47,7 +48,7 @@ namespace industrial_robot_client
 namespace joint_trajectory_action
 {
 
-const double JointTrajectoryAction::WATCHD0G_PERIOD_ = 1.0;
+const double JointTrajectoryAction::WATCHDOG_PERIOD_ = 1.0;
 const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.01;
 
 JointTrajectoryAction::JointTrajectoryAction() :
@@ -59,60 +60,36 @@ JointTrajectoryAction::JointTrajectoryAction() :
 
   pn.param("constraints/goal_threshold", goal_threshold_, DEFAULT_GOAL_THRESHOLD_);
 
-  std::map<int, RobotGroup> robot_groups;
-  if (!getJointGroups("topic_list", robot_groups))
-  {
-    // this is a WARN as this class is the multi-group version of the regular JTA,
-    // and we're actually expecting to find the 'topic_list' parameter, as using
-    // this multi-group version with a single-group system is unnecessary and also
-    // doesn't make much sense.
-    // It probably also won't work.
-    ROS_WARN("Expecting/assuming single motion-group controller configuration");
-  }
+  getJointGroups("topic_list", robot_groups_);
 
-  for (size_t i = 0; i < robot_groups.size(); i++)
+  for (size_t i = 0; i < robot_groups_.size(); i++)
   {
-    std::string joint_path_action_name = robot_groups[i].get_ns() + "/" + robot_groups[i].get_name();
-    std::vector<std::string> rg_joint_names = robot_groups[i].get_joint_names();
-    int group_number_int = robot_groups[i].get_group_id();
+    std::vector<std::string> rg_joint_names = robot_groups_[i].get_joint_names();
+    int group_number_int = robot_groups_[i].get_group_id();
 
     all_joint_names_.insert(all_joint_names_.end(), rg_joint_names.begin(), rg_joint_names.end());
 
-    actionServer_ = new actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>(
-      node_, joint_path_action_name + "/joint_trajectory_action" , false);
-    actionServer_->registerGoalCallback(
-      boost::bind(&JointTrajectoryAction::goalCB,
-                  this, _1, group_number_int));
-    actionServer_->registerCancelCallback(
-      boost::bind(&JointTrajectoryAction::cancelCB,
-                  this, _1, group_number_int));
-
-    pub_trajectory_command_ = node_.advertise<motoman_msgs::DynamicJointTrajectory>(
-                                joint_path_action_name + "/joint_path_command", 1);
-    sub_trajectory_state_  = this->node_.subscribe<control_msgs::FollowJointTrajectoryFeedback>(
-                               joint_path_action_name + "/feedback_states", 1,
-                               boost::bind(&JointTrajectoryAction::controllerStateCB,
-                                           this, _1, group_number_int));
-    sub_robot_status_ = node_.subscribe(
-                          "robot_status", 1, &JointTrajectoryAction::robotStatusCB, this);
-
-    pub_trajectories_[group_number_int] = pub_trajectory_command_;
-    sub_trajectories_[group_number_int] = (sub_trajectory_state_);
-    sub_status_[group_number_int] = (sub_robot_status_);
-
-    this->act_servers_[group_number_int] = actionServer_;
-
-    this->act_servers_[group_number_int]->start();
-
-    this->watchdog_timer_map_[group_number_int] = node_.createTimer(
-          ros::Duration(WATCHD0G_PERIOD_), boost::bind(
-            &JointTrajectoryAction::watchdog, this, _1, group_number_int));
+    // Trajectories sub-group active map initialization
+    has_active_goals_map_[group_number_int] = false;
+    // Trajectory state recvd init
+    trajectory_state_recvd_map_[group_number_int] = false;
   }
 
   pub_trajectory_command_ = node_.advertise<motoman_msgs::DynamicJointTrajectory>(
                               "joint_path_command", 1);
 
-  this->robot_groups_ = robot_groups;
+  sub_trajectory_state_  = node_.subscribe<control_msgs::FollowJointTrajectoryFeedback>(
+                              "feedback_states", 1,
+                              boost::bind(&JointTrajectoryAction::controllerStateCB, this, _1));
+
+  sub_robot_status_ = node_.subscribe("robot_status", 1, &JointTrajectoryAction::robotStatusCB, this);
+
+  // Set watchdog timer for entire robot state.
+  watchdog_timer_ = node_.createTimer(ros::Duration(WATCHDOG_PERIOD_),
+                              boost::bind(&JointTrajectoryAction::watchdog, this, _1));
+
+  has_active_goal_ = false;
+  motion_started_ = false;
 
   action_server_.start();
 }
@@ -125,6 +102,7 @@ void JointTrajectoryAction::robotStatusCB(
   const industrial_msgs::RobotStatusConstPtr &msg)
 {
   last_robot_status_ = msg;  // caching robot status for later use.
+  motion_started_ |= (msg->in_motion.val != industrial_msgs::TriState::FALSE);
 }
 
 void JointTrajectoryAction::watchdog(const ros::TimerEvent &e)
@@ -134,15 +112,29 @@ void JointTrajectoryAction::watchdog(const ros::TimerEvent &e)
   {
     ROS_DEBUG("Waiting for subscription to joint trajectory state");
   }
-  if (!trajectory_state_recvd_)
+  bool trajectory_state_recvd = true;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
   {
-    ROS_DEBUG("Trajectory state not received since last watchdog");
+    trajectory_state_recvd &= trajectory_state_recvd_map_[group_number] | !has_active_goals_map_[group_number];
+  }
+
+  if (!trajectory_state_recvd)
+  {
+    ROS_DEBUG("Trajectory state of the entire robot not received since last watchdog");
+    for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+    {
+      if (!trajectory_state_recvd_map_[group_number])
+      {
+        ROS_DEBUG("Group [%s] state not received since last watchdog",
+          robot_groups_[group_number].get_name().c_str());
+      }
+    }
   }
 
   // Aborts the active goal if the controller does not appear to be active.
   if (has_active_goal_)
   {
-    if (!trajectory_state_recvd_)
+    if (!trajectory_state_recvd)
     {
       // last_trajectory_state_ is null if the subscriber never makes a connection
       if (!last_trajectory_state_)
@@ -152,222 +144,91 @@ void JointTrajectoryAction::watchdog(const ros::TimerEvent &e)
       else
       {
         ROS_WARN_STREAM(
-          "Aborting goal because we haven't heard from the controller in " << WATCHD0G_PERIOD_ << " seconds");
+          "Aborting goal because we haven't heard from the controller in " << WATCHDOG_PERIOD_ << " seconds");
       }
       abortGoal();
     }
   }
 
-  // Reset the trajectory state received flag
-  trajectory_state_recvd_ = false;
-}
-
-void JointTrajectoryAction::watchdog(const ros::TimerEvent &e, int group_number)
-{
-  // Some debug logging
-  if (!last_trajectory_state_map_[group_number])
+  // Reset the multi-group trajectory state received flag
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
   {
-    ROS_DEBUG("Waiting for subscription to joint trajectory state");
+    trajectory_state_recvd_map_[group_number] = false;
   }
-  if (!trajectory_state_recvd_map_[group_number])
-  {
-    ROS_DEBUG("Trajectory state not received since last watchdog");
-  }
-
-  // Aborts the active goal if the controller does not appear to be active.
-  if (has_active_goal_map_[group_number])
-  {
-    if (!trajectory_state_recvd_map_[group_number])
-    {
-      // last_trajectory_state_ is null if the subscriber never makes a connection
-      if (!last_trajectory_state_map_[group_number])
-      {
-        ROS_WARN("Aborting goal because we have never heard a controller state message.");
-      }
-      else
-      {
-        ROS_WARN_STREAM(
-          "Aborting goal because we haven't heard from the controller in " << WATCHD0G_PERIOD_ << " seconds");
-      }
-      abortGoal(group_number);
-    }
-  }
-  // Reset the trajectory state received flag
-  trajectory_state_recvd_ = false;
 }
 
 void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
 {
-  gh.setAccepted();
+  ROS_DEBUG("Multi-group trajectory execution request received");
 
-  int group_number;
-
-// TODO(thiagodefreitas): change for getting the id from the group instead of a sequential checking on the map
-
-  ros::Duration last_time_from_start(0.0);
-
-  motoman_msgs::DynamicJointTrajectory dyn_traj;
-
-  for (size_t i = 0; i < gh.getGoal()->trajectory.points.size(); i++)
-  {
-    motoman_msgs::DynamicJointPoint dpoint;
-
-    for (size_t rbt_idx = 0; rbt_idx < robot_groups_.size(); rbt_idx++)
-    {
-      size_t ros_idx = std::find(
-                         gh.getGoal()->trajectory.joint_names.begin(),
-                         gh.getGoal()->trajectory.joint_names.end(),
-                         robot_groups_[rbt_idx].get_joint_names()[0])
-                       - gh.getGoal()->trajectory.joint_names.begin();
-
-      bool is_found = ros_idx < gh.getGoal()->trajectory.joint_names.size();
-
-      group_number = rbt_idx;
-      motoman_msgs::DynamicJointsGroup dyn_group;
-
-      int num_joints = robot_groups_[group_number].get_joint_names().size();
-
-      if (is_found)
-      {
-        if (gh.getGoal()->trajectory.points[i].positions.empty())
-        {
-          std::vector<double> positions(num_joints, 0.0);
-          dyn_group.positions = positions;
-        }
-        else
-          dyn_group.positions.insert(
-            dyn_group.positions.begin(),
-            gh.getGoal()->trajectory.points[i].positions.begin() + ros_idx,
-            gh.getGoal()->trajectory.points[i].positions.begin() + ros_idx
-            + robot_groups_[rbt_idx].get_joint_names().size());
-
-        if (gh.getGoal()->trajectory.points[i].velocities.empty())
-        {
-          std::vector<double> velocities(num_joints, 0.0);
-          dyn_group.velocities = velocities;
-        }
-        else
-          dyn_group.velocities.insert(
-            dyn_group.velocities.begin(),
-            gh.getGoal()->trajectory.points[i].velocities.begin()
-            + ros_idx, gh.getGoal()->trajectory.points[i].velocities.begin()
-            + ros_idx + robot_groups_[rbt_idx].get_joint_names().size());
-
-        if (gh.getGoal()->trajectory.points[i].accelerations.empty())
-        {
-          std::vector<double> accelerations(num_joints, 0.0);
-          dyn_group.accelerations = accelerations;
-        }
-        else
-          dyn_group.accelerations.insert(
-            dyn_group.accelerations.begin(),
-            gh.getGoal()->trajectory.points[i].accelerations.begin()
-            + ros_idx, gh.getGoal()->trajectory.points[i].accelerations.begin()
-            + ros_idx + robot_groups_[rbt_idx].get_joint_names().size());
-        if (gh.getGoal()->trajectory.points[i].effort.empty())
-        {
-          std::vector<double> effort(num_joints, 0.0);
-          dyn_group.effort = effort;
-        }
-        else
-          dyn_group.effort.insert(
-            dyn_group.effort.begin(),
-            gh.getGoal()->trajectory.points[i].effort.begin()
-            + ros_idx, gh.getGoal()->trajectory.points[i].effort.begin()
-            + ros_idx + robot_groups_[rbt_idx].get_joint_names().size());
-        dyn_group.time_from_start = gh.getGoal()->trajectory.points[i].time_from_start;
-        dyn_group.group_number = group_number;
-        dyn_group.num_joints = dyn_group.positions.size();
-      }
-
-      // Generating message for groups that were not present in the trajectory message
-      else
-      {
-        std::vector<double> positions(num_joints, 0.0);
-        std::vector<double> velocities(num_joints, 0.0);
-        std::vector<double> accelerations(num_joints, 0.0);
-        std::vector<double> effort(num_joints, 0.0);
-
-        dyn_group.positions = positions;
-        dyn_group.velocities = velocities;
-        dyn_group.accelerations = accelerations;
-        dyn_group.effort = effort;
-
-        dyn_group.time_from_start = gh.getGoal()->trajectory.points[i].time_from_start;
-        dyn_group.group_number = group_number;
-        dyn_group.num_joints = num_joints;
-      }
-
-      dpoint.groups.push_back(dyn_group);
-    }
-    dpoint.num_groups = dpoint.groups.size();
-    dyn_traj.points.push_back(dpoint);
-  }
-  dyn_traj.header = gh.getGoal()->trajectory.header;
-  dyn_traj.header.stamp = ros::Time::now();
-  // Publishing the joint names for the 4 groups
-  dyn_traj.joint_names = all_joint_names_;
-
-  this->pub_trajectory_command_.publish(dyn_traj);
-}
-
-void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle gh)
-{
-  // The interface is provided, but it is recommended to use
-  //  void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle & gh, int group_number)
-
-  ROS_DEBUG("Received action cancel request");
-}
-
-void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh, int group_number)
-{
   if (!gh.getGoal()->trajectory.points.empty())
   {
-    if (industrial_utils::isSimilar(
-          this->robot_groups_[group_number].get_joint_names(),
-          gh.getGoal()->trajectory.joint_names))
+    std::map<int, size_t> group_joints_start_idx;
+    ros::Duration last_time_from_start(0.0);
+
+    if (has_active_goal_)  // Cancels the currently active goal.
     {
-      // Cancels the currently active goal.
-      if (has_active_goal_map_[group_number])
+      ROS_WARN("Received new goal, canceling current goal");
+      cancelGoal();
+    }
+    // Detect which robot groups are active in the current motion trajectory
+    for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+    {
+      size_t ros_idx = std::find(
+                        gh.getGoal()->trajectory.joint_names.begin(),
+                        gh.getGoal()->trajectory.joint_names.end(),
+                        robot_groups_[group_number].get_joint_names()[0])
+                      - gh.getGoal()->trajectory.joint_names.begin();
+
+      bool is_found = ros_idx < gh.getGoal()->trajectory.joint_names.size();
+      if (is_found)
       {
-        ROS_WARN("Received new goal, canceling current goal");
-        abortGoal(group_number);
-      }
-      // Sends the trajectory along to the controller
-      if (withinGoalConstraints(last_trajectory_state_map_[group_number],
-                                gh.getGoal()->trajectory, group_number))
-      {
-        ROS_INFO_STREAM("Already within goal constraints, setting goal succeeded");
-        gh.setAccepted();
-        gh.setSucceeded();
-        has_active_goal_map_[group_number] = false;
+        has_active_goals_map_[group_number] = true;
+        group_joints_start_idx.insert(std::pair<int, size_t>(group_number, ros_idx));
+        ROS_DEBUG("Group [%s] is active in trajectory plan", robot_groups_[group_number].get_name().c_str());
       }
       else
       {
-        gh.setAccepted();
-        active_goal_map_[group_number] = gh;
-        has_active_goal_map_[group_number]  = true;
+        has_active_goals_map_[group_number] = false;
+        ROS_DEBUG("Group [%s] not present in trajectory plan, using its last received joint positions as goal",
+                                                                robot_groups_[group_number].get_name().c_str());
+      }
+    }
+    gh.setAccepted();
+    active_goal_ = gh;
+    has_active_goal_ = true;
+    motoman_msgs::DynamicJointTrajectory dyn_traj;
 
-        ROS_INFO("Publishing trajectory");
+    ROS_DEBUG("Publishing trajectory");
 
-        current_traj_map_[group_number] = active_goal_map_[group_number].getGoal()->trajectory;
+    current_traj_ = active_goal_.getGoal()->trajectory;
+
+    for (int i = 0; i < gh.getGoal()->trajectory.points.size(); i++)
+    {
+      motoman_msgs::DynamicJointPoint dpoint;
+
+      for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+      {
+        motoman_msgs::DynamicJointsGroup dyn_group;
 
         int num_joints = robot_groups_[group_number].get_joint_names().size();
 
-        motoman_msgs::DynamicJointTrajectory dyn_traj;
-
-        for (size_t i = 0; i < current_traj_map_[group_number].points.size(); ++i)
+        if (has_active_goals_map_[group_number])  // If group is active on current goal
         {
-          motoman_msgs::DynamicJointsGroup dyn_group;
-          motoman_msgs::DynamicJointPoint dyn_point;
-
           if (gh.getGoal()->trajectory.points[i].positions.empty())
           {
             std::vector<double> positions(num_joints, 0.0);
             dyn_group.positions = positions;
           }
           else
-            dyn_group.positions = gh.getGoal()->trajectory.points[i].positions;
+          {
+            // This assumes joints in the same group are sequential and in the group-defined order.
+            dyn_group.positions.insert(
+              dyn_group.positions.begin(),
+              gh.getGoal()->trajectory.points[i].positions.begin() + group_joints_start_idx[group_number],
+              gh.getGoal()->trajectory.points[i].positions.begin() + group_joints_start_idx[group_number]
+              + robot_groups_[group_number].get_joint_names().size());
+          }
 
           if (gh.getGoal()->trajectory.points[i].velocities.empty())
           {
@@ -375,55 +236,91 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh, int
             dyn_group.velocities = velocities;
           }
           else
-            dyn_group.velocities = gh.getGoal()->trajectory.points[i].velocities;
+          {
+            dyn_group.velocities.insert(
+              dyn_group.velocities.begin(),
+              gh.getGoal()->trajectory.points[i].velocities.begin() + group_joints_start_idx[group_number],
+              gh.getGoal()->trajectory.points[i].velocities.begin() + group_joints_start_idx[group_number]
+              + robot_groups_[group_number].get_joint_names().size());
+          }
+
           if (gh.getGoal()->trajectory.points[i].accelerations.empty())
           {
             std::vector<double> accelerations(num_joints, 0.0);
             dyn_group.accelerations = accelerations;
           }
           else
-            dyn_group.accelerations = gh.getGoal()->trajectory.points[i].accelerations;
+          {
+            dyn_group.accelerations.insert(
+              dyn_group.accelerations.begin(),
+              gh.getGoal()->trajectory.points[i].accelerations.begin() + group_joints_start_idx[group_number],
+              gh.getGoal()->trajectory.points[i].accelerations.begin() + group_joints_start_idx[group_number]
+                + robot_groups_[group_number].get_joint_names().size());
+          }
+
           if (gh.getGoal()->trajectory.points[i].effort.empty())
           {
             std::vector<double> effort(num_joints, 0.0);
             dyn_group.effort = effort;
           }
           else
-            dyn_group.effort = gh.getGoal()->trajectory.points[i].effort;
+          {
+            dyn_group.effort.insert(
+              dyn_group.effort.begin(),
+              gh.getGoal()->trajectory.points[i].effort.begin() + group_joints_start_idx[group_number],
+              gh.getGoal()->trajectory.points[i].effort.begin() + group_joints_start_idx[group_number]
+                + robot_groups_[group_number].get_joint_names().size());
+          }
+
           dyn_group.time_from_start = gh.getGoal()->trajectory.points[i].time_from_start;
           dyn_group.group_number = group_number;
-          dyn_group.num_joints = robot_groups_[group_number].get_joint_names().size();
-          dyn_point.groups.push_back(dyn_group);
-
-          dyn_point.num_groups = 1;
-          dyn_traj.points.push_back(dyn_point);
+          dyn_group.num_joints = dyn_group.positions.size();
         }
-        dyn_traj.header = gh.getGoal()->trajectory.header;
-        dyn_traj.joint_names = gh.getGoal()->trajectory.joint_names;
-        this->pub_trajectories_[group_number].publish(dyn_traj);
+
+        // Generating message for groups that were not present in the trajectory message
+        // Assume that joints from these groups will mantain its current position.
+        // Velocity, acceleration and effort are zero out.
+        else
+        {
+          std::vector<double> positions = last_trajectory_state_map_[group_number]->actual.positions;
+          std::vector<double> velocities(num_joints, 0.0);
+          std::vector<double> accelerations(num_joints, 0.0);
+          std::vector<double> effort(num_joints, 0.0);
+
+          dyn_group.positions = positions;
+          dyn_group.velocities = velocities;
+          dyn_group.accelerations = accelerations;
+          dyn_group.effort = effort;
+
+          dyn_group.time_from_start = gh.getGoal()->trajectory.points[i].time_from_start;
+          dyn_group.group_number = group_number;
+          dyn_group.num_joints = num_joints;
+        }
+
+        dpoint.groups.push_back(dyn_group);
       }
+
+      dpoint.num_groups = dpoint.groups.size();
+      dyn_traj.points.push_back(dpoint);
     }
-    else
-    {
-      ROS_ERROR("Joint trajectory action failing on invalid joints");
-      control_msgs::FollowJointTrajectoryResult rslt;
-      rslt.error_code = control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS;
-      gh.setRejected(rslt, "Joint names do not match");
-    }
+
+    dyn_traj.header = gh.getGoal()->trajectory.header;
+    dyn_traj.header.stamp = ros::Time::now();
+    // Publishing the joint names for the 4 groups
+    dyn_traj.joint_names = all_joint_names_;
+
+    motion_started_ = false;
+    this->pub_trajectory_command_.publish(dyn_traj);
   }
   else
   {
-    ROS_ERROR("Joint trajectory action failed on empty trajectory");
+    ROS_ERROR("Multi-group joint trajectory action failed on empty trajectory");
     control_msgs::FollowJointTrajectoryResult rslt;
     rslt.error_code = control_msgs::FollowJointTrajectoryResult::INVALID_GOAL;
     gh.setRejected(rslt, "Empty trajectory");
   }
 
   // Adding some informational log messages to indicate unsupported goal constraints
-  if (gh.getGoal()->goal_time_tolerance.toSec() > 0.0)
-  {
-    ROS_WARN_STREAM("Ignoring goal time tolerance in action goal, may be supported in the future");
-  }
   if (!gh.getGoal()->goal_tolerance.empty())
   {
     ROS_WARN_STREAM(
@@ -435,20 +332,12 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh, int
   }
 }
 
-void JointTrajectoryAction::cancelCB(
-  JointTractoryActionServer::GoalHandle gh, int group_number)
+void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle gh)
 {
   ROS_DEBUG("Received action cancel request");
-  if (active_goal_map_[group_number] == gh)
+  if (has_active_goal_ && active_goal_ == gh)
   {
-    // Stops the controller.
-    motoman_msgs::DynamicJointTrajectory empty;
-    empty.joint_names = robot_groups_[group_number].get_joint_names();
-    this->pub_trajectories_[group_number].publish(empty);
-
-    // Marks the current goal as canceled.
-    active_goal_map_[group_number].setCanceled();
-    has_active_goal_map_[group_number] = false;
+    cancelGoal();
   }
   else
   {
@@ -457,91 +346,63 @@ void JointTrajectoryAction::cancelCB(
 }
 
 void JointTrajectoryAction::controllerStateCB(
-  const control_msgs::FollowJointTrajectoryFeedbackConstPtr &msg, int robot_id)
-{
-  ROS_DEBUG("Checking controller state feedback");
-  last_trajectory_state_map_[robot_id] = msg;
-  trajectory_state_recvd_map_[robot_id] = true;
-
-  if (!has_active_goal_map_[robot_id])
-  {
-    ROS_DEBUG("No active goal, ignoring feedback");
-    return;
-  }
-
-  if (current_traj_map_[robot_id].points.empty())
-  {
-    ROS_DEBUG("Current trajectory is empty, ignoring feedback");
-    return;
-  }
-
-  if (!industrial_utils::isSimilar(robot_groups_[robot_id].get_joint_names(), msg->joint_names))
-  {
-    ROS_ERROR("Joint names from the controller don't match our joint names.");
-    return;
-  }
-
-  // Checking for goal constraints
-  // Checks that we have ended inside the goal constraints and has motion stopped
-
-  ROS_DEBUG("Checking goal constraints");
-  if (withinGoalConstraints(last_trajectory_state_map_[robot_id], current_traj_map_[robot_id], robot_id))
-  {
-    if (last_robot_status_)
-    {
-      // Additional check for motion stoppage since the controller goal may still
-      // be moving.  The current robot driver calls a motion stop if it receives
-      // a new trajectory while it is still moving.  If the driver is not publishing
-      // the motion state (i.e. old driver), this will still work, but it warns you.
-      if (last_robot_status_->in_motion.val == industrial_msgs::TriState::FALSE)
-      {
-        ROS_INFO("Inside goal constraints, stopped moving, return success for action");
-        active_goal_map_[robot_id].setSucceeded();
-        has_active_goal_map_[robot_id] = false;
-      }
-      else if (last_robot_status_->in_motion.val == industrial_msgs::TriState::UNKNOWN)
-      {
-        ROS_INFO("Inside goal constraints, return success for action");
-        ROS_WARN("Robot status in motion unknown, the robot driver node and controller code should be updated");
-        active_goal_map_[robot_id].setSucceeded();
-        has_active_goal_map_[robot_id] = false;
-      }
-      else
-      {
-        ROS_DEBUG("Within goal constraints but robot is still moving");
-      }
-    }
-    else
-    {
-      ROS_INFO("Inside goal constraints, return success for action");
-      ROS_WARN("Robot status is not being published the robot driver node and controller code should be updated");
-      active_goal_map_[robot_id].setSucceeded();
-      has_active_goal_map_[robot_id] = false;
-    }
-  }
-}
-
-void JointTrajectoryAction::controllerStateCB(
   const control_msgs::FollowJointTrajectoryFeedbackConstPtr &msg)
 {
   ROS_DEBUG("Checking controller state feedback");
-  last_trajectory_state_ = msg;
-  trajectory_state_recvd_ = true;
 
-  if (!has_active_goal_)
+  // Full robot state is marked as received if all robot groups states have been received.
+  int msg_group = -1;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
   {
-    ROS_DEBUG("No active goal, ignoring feedback");
+    size_t idx = std::find(msg->joint_names.begin(),
+                           msg->joint_names.end(),
+                           robot_groups_[group_number].get_joint_names()[0])
+                          - msg->joint_names.begin();
+
+    bool is_found = idx < msg->joint_names.size();
+    if (is_found)
+    {
+      msg_group = group_number;
+      break;
+    }
+  }
+
+  if (msg_group == -1)
+  {
+    ROS_WARN("Unrecognized controller feedback message");
     return;
   }
+
+  last_trajectory_state_ = msg;
+  trajectory_state_recvd_map_[msg_group] = true;
+  last_trajectory_state_map_[msg_group] = msg;
+
+  bool trajectory_state_recvd = true;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+  {
+    trajectory_state_recvd &= trajectory_state_recvd_map_[group_number] | !has_active_goals_map_[group_number];
+  }
+
+  if (!trajectory_state_recvd)
+  {
+    ROS_DEBUG("Waiting for all robot groups feedback states before processing multi-group feedback");
+    return;
+  }
+  if (!has_active_goal_)
+  {
+    ROS_DEBUG("No active multi-group goal, ignoring feedback");
+    return;
+  }
+
   if (current_traj_.points.empty())
   {
     ROS_DEBUG("Current trajectory is empty, ignoring feedback");
     return;
   }
 
-  if (!industrial_utils::isSimilar(all_joint_names_, msg->joint_names))
+  if (!motion_started_)
   {
-    ROS_ERROR("Joint names from the controller don't match our joint names.");
+    ROS_DEBUG("Motion has not started, ignoring feedback");
     return;
   }
 
@@ -549,26 +410,25 @@ void JointTrajectoryAction::controllerStateCB(
   // Checks that we have ended inside the goal constraints and has motion stopped
 
   ROS_DEBUG("Checking goal constraints");
-  if (withinGoalConstraints(last_trajectory_state_, current_traj_))
+  if (withinGoalConstraints(current_traj_))
   {
     if (last_robot_status_)
     {
       // Additional check for motion stoppage since the controller goal may still
-      // be moving.  The current robot driver calls a motion stop if it receives
+      // be moving.  The current robot driver calls a motion stop if it receivesjoint_traj_client
       // a new trajectory while it is still moving.  If the driver is not publishing
       // the motion state (i.e. old driver), this will still work, but it warns you.
       if (last_robot_status_->in_motion.val == industrial_msgs::TriState::FALSE)
       {
         ROS_INFO("Inside goal constraints, stopped moving, return success for action");
-        active_goal_.setSucceeded();
-        has_active_goal_ = false;
+        setGoalSuccess();
       }
       else if (last_robot_status_->in_motion.val == industrial_msgs::TriState::UNKNOWN)
       {
+        // TODO(NA): Should this really return succeeded?
         ROS_INFO("Inside goal constraints, return success for action");
         ROS_WARN("Robot status in motion unknown, the robot driver node and controller code should be updated");
-        active_goal_.setSucceeded();
-        has_active_goal_ = false;
+        setGoalSuccess();
       }
       else
       {
@@ -579,95 +439,126 @@ void JointTrajectoryAction::controllerStateCB(
     {
       ROS_INFO("Inside goal constraints, return success for action");
       ROS_WARN("Robot status is not being published the robot driver node and controller code should be updated");
-      active_goal_.setSucceeded();
-      has_active_goal_ = false;
+      setGoalSuccess();
     }
+  }
+  else if (last_robot_status_->in_motion.val == industrial_msgs::TriState::FALSE)
+  {
+    ROS_WARN("Outside goal constraints, aborting trajectory");
+    abortGoal();
+  }
+}
+
+void JointTrajectoryAction::setGoalSuccess()
+{
+  ROS_INFO("Marking goal as successful.");
+
+  // Marks the current goal as aborted.
+  active_goal_.setSucceeded();
+  has_active_goal_ = false;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+  {
+    has_active_goals_map_[group_number] = false;
   }
 }
 
 void JointTrajectoryAction::abortGoal()
 {
+  ROS_INFO("Aborting active goal.");
   // Stops the controller.
-  trajectory_msgs::JointTrajectory empty;
+  motoman_msgs::DynamicJointTrajectory empty;
   pub_trajectory_command_.publish(empty);
 
   // Marks the current goal as aborted.
   active_goal_.setAborted();
   has_active_goal_ = false;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+  {
+    has_active_goals_map_[group_number] = false;
+  }
 }
 
-void JointTrajectoryAction::abortGoal(int robot_id)
+void JointTrajectoryAction::cancelGoal()
 {
+  ROS_INFO("Cancelling active goal.");
   // Stops the controller.
   motoman_msgs::DynamicJointTrajectory empty;
-  pub_trajectories_[robot_id].publish(empty);
+  pub_trajectory_command_.publish(empty);
 
   // Marks the current goal as aborted.
-  active_goal_map_[robot_id].setAborted();
-  has_active_goal_map_[robot_id] = false;
+  active_goal_.setCanceled();
+  has_active_goal_ = false;
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
+  {
+    has_active_goals_map_[group_number] = false;
+  }
 }
 
-bool JointTrajectoryAction::withinGoalConstraints(
-  const control_msgs::FollowJointTrajectoryFeedbackConstPtr &msg,
-  const trajectory_msgs::JointTrajectory & traj)
+bool JointTrajectoryAction::withinGoalConstraints(const trajectory_msgs::JointTrajectory & traj)
 {
-  bool rtn = false;
   if (traj.points.empty())
   {
     ROS_WARN("Empty joint trajectory passed to check goal constraints, return false");
-    rtn = false;
+    return false;
   }
-  else
+
+  // Assume true, and proof wrong by checking each robot group that is active in current goal
+  std::map<int, bool> groups_at_goal_state_map;
+  int last_point = traj.points.size() - 1;
+
+  for (int group_number = 0; group_number < robot_groups_.size(); group_number++)
   {
-    int last_point = traj.points.size() - 1;
+    // Check if robot group is active in current multi-group trajectory goal.
+    if (has_active_goals_map_[group_number])
+    {
+      ROS_DEBUG("Checking if group [%s] has reached its goal", robot_groups_[group_number].get_name().c_str());
+      // Asume group is not at goal position
+      groups_at_goal_state_map[group_number] = false;
 
-    if (industrial_robot_client::utils::isWithinRange(
-          last_trajectory_state_->joint_names,
-          last_trajectory_state_->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_))
-    {
-      rtn = true;
-    }
-    else
-    {
-      rtn = false;
+      // Again this assumes that joints are defined in-order within their groups.
+      size_t group_joints_start_idx = std::find(
+                      traj.joint_names.begin(),
+                      traj.joint_names.end(),
+                      robot_groups_[group_number].get_joint_names()[0])
+                    - traj.joint_names.begin();
+      // Get an ordered map of the robot group last feedback state.
+      std::map<std::string, double> robot_group_last_state_map;
+      industrial_robot_client::utils::toMap(robot_groups_[group_number].get_joint_names(),
+                                            last_trajectory_state_map_[group_number]->actual.positions,
+                                            robot_group_last_state_map);
+      // Get an ordered map of the robot group goal state.
+      std::vector<double> group_goal_positions(
+              traj.points[last_point].positions.begin() + group_joints_start_idx,
+              traj.points[last_point].positions.begin() + group_joints_start_idx
+                + robot_groups_[group_number].get_joint_names().size());
+      std::map<std::string, double> group_traj_last_point_map;
+      industrial_robot_client::utils::toMap(robot_groups_[group_number].get_joint_names(),
+                                            group_goal_positions,
+                                            group_traj_last_point_map);
+      // Check if group is already at goal position
+      if ( !industrial_robot_client::utils::isWithinRange(robot_groups_[group_number].get_joint_names(),
+                                                        group_traj_last_point_map,
+                                                        robot_group_last_state_map,
+                                                        goal_threshold_) )
+      {
+        // Current Robot Group is not in goal position yet
+        groups_at_goal_state_map[group_number] = false;
+        return false;        // Stop checking other sub-groups
+      }
+      else
+      {
+        groups_at_goal_state_map[group_number] = true;
+      }
     }
   }
-  return rtn;
-}
-
-bool JointTrajectoryAction::withinGoalConstraints(
-  const control_msgs::FollowJointTrajectoryFeedbackConstPtr &msg,
-  const trajectory_msgs::JointTrajectory & traj, int robot_id)
-{
-  bool rtn = false;
-  if (traj.points.empty())
+  if (groups_at_goal_state_map.empty())
   {
-    ROS_WARN("Empty joint trajectory passed to check goal constraints, return false");
-    rtn = false;
+    ROS_ERROR("Multi-group goal has not a single active group");
+    return false;
   }
-  else
-  {
-    int last_point = traj.points.size() - 1;
-
-    int group_number = robot_id;
-
-    if (industrial_robot_client::utils::isWithinRange(
-          robot_groups_[group_number].get_joint_names(),
-          last_trajectory_state_map_[group_number]->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_))
-    {
-      rtn = true;
-    }
-    else
-    {
-      rtn = false;
-    }
-  }
-  return rtn;
+  // If this point is reached, all active groups are at goal position
+  return true;
 }
 
 }  // namespace joint_trajectory_action
 }  // namespace industrial_robot_client
-
-

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -738,4 +738,3 @@ void JointTrajectoryInterface::jointStateCB(
 
 }  // namespace joint_trajectory_interface
 }   // namespace industrial_robot_client
-

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_streamer.cpp
@@ -245,7 +245,7 @@ void JointTrajectoryStreamer::streamingThread()
     switch (this->state_)
     {
     case TransferStates::IDLE:
-      ros::Duration(0.250).sleep();  //  slower loop while waiting for new trajectory
+      ros::Duration(0.010).sleep();  //  slower loop while waiting for new trajectory
       break;
 
     case TransferStates::STREAMING:
@@ -300,4 +300,3 @@ void JointTrajectoryStreamer::trajectoryStop()
 
 }  // namespace joint_trajectory_streamer
 }  // namespace industrial_robot_client
-

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -33,6 +33,7 @@
 #include "motoman_driver/simple_message/messages/motoman_motion_reply_message.h"
 #include "simple_message/messages/joint_traj_pt_full_message.h"
 #include "motoman_driver/simple_message/messages/joint_traj_pt_full_ex_message.h"
+#include "motoman_msgs/MotorosError.h"
 #include "industrial_robot_client/utils.h"
 #include "industrial_utils/param_utils.h"
 #include <map>
@@ -93,6 +94,8 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
 
   srv_select_tool_ = node_.advertiseService("select_tool", &MotomanJointTrajectoryStreamer::selectToolCB, this);
 
+  motoros_error_pub_ = node_.advertise<motoman_msgs::MotorosError>("motoros_error", 10);
+
   return rtn;
 }
 
@@ -117,6 +120,8 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
 
   srv_select_tool_ = node_.advertiseService("select_tool", &MotomanJointTrajectoryStreamer::selectToolCB, this);
+
+  motoros_error_pub_ = node_.advertise<motoman_msgs::MotorosError>("motoros_error", 10);
 
   return rtn;
 }
@@ -548,6 +553,13 @@ void MotomanJointTrajectoryStreamer::streamingThread()
                            << " (#" << this->current_point_ << "): "
                            << MotomanMotionCtrl::getErrorString(reply_status.reply_));
           this->state_ = TransferStates::IDLE;
+
+          motoman_msgs::MotorosError error;
+          error.code = reply_status.reply_.getResult();
+          error.subcode = reply_status.reply_.getSubcode();
+          error.code_description = reply_status.reply_.getResultString();
+          error.subcode_description = reply_status.reply_.getSubcodeString();
+          motoros_error_pub_.publish(error);
           break;
         }
       }

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -419,6 +419,13 @@ bool MotomanJointTrajectoryStreamer::VectorToJointData(const std::vector<double>
   return true;
 }
 
+void MotomanJointTrajectoryStreamer::shutdown()
+{
+  std_srvs::Trigger::Request req;
+  std_srvs::Trigger::Response res;
+  disableRobotCB(req, res);
+}
+
 // override send_to_robot to provide controllerReady() and setTrajMode() calls
 bool MotomanJointTrajectoryStreamer::send_to_robot(const std::vector<SimpleMessage>& messages)
 {

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -483,7 +483,7 @@ void MotomanJointTrajectoryStreamer::streamingThread()
     switch (this->state_)
     {
     case TransferStates::IDLE:
-      ros::Duration(0.250).sleep();  //  slower loop while waiting for new trajectory
+      ros::Duration(0.010).sleep();  //  slower loop while waiting for new trajectory
       break;
 
     case TransferStates::STREAMING:
@@ -640,4 +640,3 @@ bool MotomanJointTrajectoryStreamer::is_valid(const motoman_msgs::DynamicJointTr
 
 }  // namespace joint_trajectory_streamer
 }  // namespace motoman
-

--- a/motoman_msgs/CMakeLists.txt
+++ b/motoman_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ add_message_files(
     DynamicJointState.msg
     DynamicJointTrajectory.msg
     DynamicJointTrajectoryFeedback.msg
+    MotorosError.msg
 )
 
 add_service_files(

--- a/motoman_msgs/msg/MotorosError.msg
+++ b/motoman_msgs/msg/MotorosError.msg
@@ -1,0 +1,6 @@
+# Message to represent errors in the motoros driver.
+
+int32 code
+int32 subcode
+string code_description
+string subcode_description


### PR DESCRIPTION
Changes required to reliably control and execute joint trajectories on our multigroup system. This was tested and verified with a Yaskawa multi-group robot with one GP7 arm attached to a rail. This was **not** tested on a single-group robot to verify backwards compatibility - we suspect a small amount of work is still required to make these changes compatible with a single-group robot.

Changes were motivated by discussion in https://github.com/ros-industrial/motoman/issues/450

Notable updates include:

- Add support for commanding multi-group robots through the joint trajectory action interface.
- Update the joint trajectory action server to only begin checking for successful trajectory end conditions after the trajectory is expected to end, in order to allow for trajectories with the same start and end position.
- Propagate motoros errors to the joint trajectory action node to abort the trajectory in case of motoros failure.
- Add a shutdown handler to verify the robot is disabled on exit.