### PR TITLE
gp200r: add missing dependency on resources pkg

### DIFF
--- a/motoman_gp200r_support/package.xml
+++ b/motoman_gp200r_support/package.xml
@@ -45,6 +45,7 @@
 
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
+  <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>


### PR DESCRIPTION
As per subject.

Seems I missed this in the review of #452.

