### PR TITLE
Fix for "within range" error

### DIFF
--- a/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -54,6 +54,8 @@ using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreame
 using industrial::simple_message::SimpleMessage;
 using industrial::smpl_msg_connection::SmplMsgConnection;
 
+enum class MotomanControllerType { DX100, DX200, FS100, YRC1000 };
+
 /**
  * \brief Message handler that streams joint trajectories to the robot controller.
  *        Contains FS100-specific motion control commands.
@@ -134,6 +136,7 @@ public:
 
 protected:
   int robot_id_;
+  MotomanControllerType robot_controller_type_;
   MotomanMotionCtrl motion_ctrl_;
 
   // used to enforce serialisation of all access to the single, shared SmplMsgConnection.

--- a/motoman_driver/launch/robot_interface_streaming.launch
+++ b/motoman_driver/launch/robot_interface_streaming.launch
@@ -21,12 +21,16 @@
 	<!-- robot_ip: IP-address of the robot's socket-messaging server -->
 	<arg name="robot_ip" doc="IP of controller" />
 
+	<!-- robot_controller: type of robot controller used with robot -->
+	<arg name="robot_controller" doc="type of robot controller" />
+
 	<!-- Load the byte-swapping versions of Fanuc nodes if required -->
 	<arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
 	<!-- copy the specified parameters to the Parameter Server, for 
 	     use by nodes below -->
 	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+	<param name="robot_controller" type="str" value="$(arg robot_controller)" />
 
 	<!-- robot_state: publishes joint positions and robot-state data
 	     (from socket connection to robot)

--- a/motoman_driver/launch/robot_interface_streaming_dx100.launch
+++ b/motoman_driver/launch/robot_interface_streaming_dx100.launch
@@ -7,6 +7,7 @@
 -->
 <launch>
 	<arg name="robot_ip" doc="IP of controller" />
+	<arg name="robot_controller" default="dx100" doc="type of robot controller" />
 	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
@@ -14,6 +15,7 @@
 
 	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
 		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="robot_controller"   value="$(arg robot_controller)" />
 		<arg name="use_bswap"  value="$(arg use_bswap)" />
 		<arg name="version0"  value="$(arg version0)" />
 	</include>

--- a/motoman_driver/launch/robot_interface_streaming_dx200.launch
+++ b/motoman_driver/launch/robot_interface_streaming_dx200.launch
@@ -7,6 +7,7 @@
 -->
 <launch>
 	<arg name="robot_ip" doc="IP of controller" />
+	<arg name="robot_controller" default="dx200" doc="type of robot controller" />
 	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
@@ -14,6 +15,7 @@
 
 	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
 		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="robot_controller"   value="$(arg robot_controller)" />
 		<arg name="use_bswap"  value="$(arg use_bswap)" />
 		<arg name="version0"  value="$(arg version0)" />
 	</include>

--- a/motoman_driver/launch/robot_interface_streaming_fs100.launch
+++ b/motoman_driver/launch/robot_interface_streaming_fs100.launch
@@ -7,6 +7,7 @@
 -->
 <launch>
 	<arg name="robot_ip" doc="IP of controller" />
+	<arg name="robot_controller" default="fs100" doc="type of robot controller" />
 	<arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
@@ -14,6 +15,7 @@
 
 	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
 		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="robot_controller"   value="$(arg robot_controller)" />
 		<arg name="use_bswap"  value="$(arg use_bswap)" />
 		<arg name="version0"  value="$(arg version0)" />
 	</include>

--- a/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
+++ b/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
@@ -7,6 +7,7 @@
 -->
 <launch>
 	<arg name="robot_ip" doc="IP of controller" />
+	<arg name="robot_controller" default="yrc1000" doc="type of robot controller" />
 	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
@@ -14,6 +15,7 @@
 
 	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
 		<arg name="robot_ip"   value="$(arg robot_ip)" />
+		<arg name="robot_controller"   value="$(arg robot_controller)" />
 		<arg name="use_bswap"  value="$(arg use_bswap)" />
 		<arg name="version0"  value="$(arg version0)" />
 	</include>


### PR DESCRIPTION
While using Motoman GP12 with ROS I regularly got problem: "Trajectory start position doesn't match current robot position". I found, that, after complete moveit trajectory, robot position have small fluctuation (within 0.005 rad) for couple of seconds. If moveit generate plan while position changing - error occured. I checked motoman code, that generated error message, and found that it belong to FS100 controller. But my GP12 had YRC1000. I disabled that check and my robot worked fine for hours. Seems like this check really needed for FS100, not YRC1000.
I wrote fix for that [roblem in this pull request.