### PR TITLE
Switch to JSP GUI in all `test_<model>.launch` files

### DIFF
--- a/motoman_ar2010_support/package.xml
+++ b/motoman_ar2010_support/package.xml
@@ -47,7 +47,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp12_support/launch/test_gp12.launch
+++ b/motoman_gp12_support/launch/test_gp12.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_gp12_support)/launch/load_gp12.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp12_support/package.xml
+++ b/motoman_gp12_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp180_support/launch/test_gp180_120.launch
+++ b/motoman_gp180_support/launch/test_gp180_120.launch
@@ -1,10 +1,6 @@
 <launch>
     <include file="$(find motoman_gp180_support)/launch/load_gp180_120.launch" />
-
-    <param name="use_gui" value="true" />
-
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+    <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp180_support/package.xml
+++ b/motoman_gp180_support/package.xml
@@ -50,7 +50,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>

--- a/motoman_gp200r_support/launch/test_gp200r.launch
+++ b/motoman_gp200r_support/launch/test_gp200r.launch
@@ -1,10 +1,6 @@
 <launch>
     <include file="$(find motoman_gp200r_support)/launch/load_gp200r.launch" />
-
-    <param name="use_gui" value="true" />
-
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+    <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp200r_support/package.xml
+++ b/motoman_gp200r_support/package.xml
@@ -43,7 +43,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp215_support/launch/test_gp215.launch
+++ b/motoman_gp215_support/launch/test_gp215.launch
@@ -1,6 +1,5 @@
 <launch>
   <include file="$(find motoman_gp215_support)/launch/load_gp215.launch" />
-  <param name="use_gui" value="true" />
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />

--- a/motoman_gp250_support/launch/test_gp250.launch
+++ b/motoman_gp250_support/launch/test_gp250.launch
@@ -1,6 +1,5 @@
 <launch>
   <include file="$(find motoman_gp250_support)/launch/load_gp250.launch" />
-  <param name="use_gui" value="true" />
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />

--- a/motoman_gp25_support/launch/test_gp25.launch
+++ b/motoman_gp25_support/launch/test_gp25.launch
@@ -1,9 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <include file="$(find motoman_gp25_support)/launch/load_gp25.launch" />
-  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" >
-    <param name="use_gui" value="true" />
-  </node>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp35l_support/launch/test_gp35l.launch
+++ b/motoman_gp35l_support/launch/test_gp35l.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_gp35l_support)/launch/load_gp35l.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp35l_support/package.xml
+++ b/motoman_gp35l_support/package.xml
@@ -43,7 +43,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp4_support/launch/test_gp4.launch
+++ b/motoman_gp4_support/launch/test_gp4.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_gp4_support)/launch/load_gp4.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp4_support/package.xml
+++ b/motoman_gp4_support/package.xml
@@ -44,7 +44,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp50_support/launch/test_gp50.launch
+++ b/motoman_gp50_support/launch/test_gp50.launch
@@ -1,9 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <include file="$(find motoman_gp50_support)/launch/load_gp50.launch" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" >
-    <param name="use_gui" value="true" />
-  </node>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp50_support/package.xml
+++ b/motoman_gp50_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp70l_support/launch/test_gp70l.launch
+++ b/motoman_gp70l_support/launch/test_gp70l.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_gp70l_support)/launch/load_gp70l.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp70l_support/package.xml
+++ b/motoman_gp70l_support/package.xml
@@ -43,7 +43,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp7_support/launch/test_gp7.launch
+++ b/motoman_gp7_support/launch/test_gp7.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_gp7_support)/launch/load_gp7.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp7_support/package.xml
+++ b/motoman_gp7_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp88_support/launch/test_gp88.launch
+++ b/motoman_gp88_support/launch/test_gp88.launch
@@ -1,11 +1,6 @@
 <launch>
   <include file="$(find motoman_gp88_support)/launch/load_gp88.launch" />
-
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="true" />
-  </node>
-
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp88_support/package.xml
+++ b/motoman_gp88_support/package.xml
@@ -42,7 +42,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_gp8_support/launch/test_gp8.launch
+++ b/motoman_gp8_support/launch/test_gp8.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_gp8_support)/launch/load_gp8.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp8_support/package.xml
+++ b/motoman_gp8_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_hc10_support/launch/test_hc10.launch
+++ b/motoman_hc10_support/launch/test_hc10.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_hc10_support)/launch/load_hc10.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_hc10_support/launch/test_hc10dt.launch
+++ b/motoman_hc10_support/launch/test_hc10dt.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_hc10_support)/launch/load_hc10dt.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_hc10_support/launch/test_hc10dt_b10.launch
+++ b/motoman_hc10_support/launch/test_hc10dt_b10.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_hc10_support)/launch/load_hc10dt_b10.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_hc10_support/launch/test_hc10dtp_b00.launch
+++ b/motoman_hc10_support/launch/test_hc10dtp_b00.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_hc10_support)/launch/load_hc10dtp_b00.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_hc10_support/package.xml
+++ b/motoman_hc10_support/package.xml
@@ -60,7 +60,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_hc20_support/launch/test_hc20.launch
+++ b/motoman_hc20_support/launch/test_hc20.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_hc20_support)/launch/load_hc20.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_hc20_support/package.xml
+++ b/motoman_hc20_support/package.xml
@@ -46,7 +46,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_mh12_support/launch/test_mh12.launch
+++ b/motoman_mh12_support/launch/test_mh12.launch
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
       <include file="$(find motoman_mh12_support)/launch/load_mh12.launch" />
-      <param name="use_gui" value="true" />
-      <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+      <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
       <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
       <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh12_support/package.xml
+++ b/motoman_mh12_support/package.xml
@@ -17,7 +17,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_mh50_support/launch/test_mh50.launch
+++ b/motoman_mh50_support/launch/test_mh50.launch
@@ -1,8 +1,6 @@
-
 <launch>
 	<include file="$(find motoman_mh50_support)/launch/load_mh50.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+    <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh50_support/package.xml
+++ b/motoman_mh50_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_mh5_support/launch/test_mh5.launch
+++ b/motoman_mh5_support/launch/test_mh5.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_mh5_support)/launch/load_mh5.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh5_support/package.xml
+++ b/motoman_mh5_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_motomini_support/launch/test_motomini.launch
+++ b/motoman_motomini_support/launch/test_motomini.launch
@@ -1,8 +1,6 @@
-
 <launch>
   <include file="$(find motoman_motomini_support)/launch/load_motomini.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_motomini_support/package.xml
+++ b/motoman_motomini_support/package.xml
@@ -42,7 +42,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_mpx1950_support/launch/test_mpx1950.launch
+++ b/motoman_mpx1950_support/launch/test_mpx1950.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_mpx1950_support)/launch/load_mpx1950.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mpx1950_support/package.xml
+++ b/motoman_mpx1950_support/package.xml
@@ -49,7 +49,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sda10f_moveit_config/package.xml
+++ b/motoman_sda10f_moveit_config/package.xml
@@ -21,7 +21,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>industrial_robot_simulator</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_sda10f_support</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>

--- a/motoman_sda10f_support/launch/test_sda10f.launch
+++ b/motoman_sda10f_support/launch/test_sda10f.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sda10f_support/package.xml
+++ b/motoman_sda10f_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia10d_support/launch/test_sia10d.launch
+++ b/motoman_sia10d_support/launch/test_sia10d.launch
@@ -1,8 +1,7 @@
 
 <launch>
 	<include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10d_support/package.xml
+++ b/motoman_sia10d_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia10f_support/launch/test_sia10f.launch
+++ b/motoman_sia10f_support/launch/test_sia10f.launch
@@ -1,8 +1,6 @@
-
 <launch>
 	<include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10f_support/package.xml
+++ b/motoman_sia10f_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia20d_moveit_config/package.xml
+++ b/motoman_sia20d_moveit_config/package.xml
@@ -21,7 +21,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>industrial_robot_simulator</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_sia20d_support</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>

--- a/motoman_sia20d_support/launch/test_sia20d.launch
+++ b/motoman_sia20d_support/launch/test_sia20d.launch
@@ -1,7 +1,6 @@
 <launch>
 	<include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+    <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia20d_support/package.xml
+++ b/motoman_sia20d_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia30d_support/launch/test_sia30d.launch
+++ b/motoman_sia30d_support/launch/test_sia30d.launch
@@ -1,9 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <include file="$(find motoman_sia30d_support)/launch/load_sia30d.launch" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" >
-    <param name="use_gui" value="true" />
-  </node>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia30d_support/package.xml
+++ b/motoman_sia30d_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia50_support/launch/test_sia50.launch
+++ b/motoman_sia50_support/launch/test_sia50.launch
@@ -1,7 +1,6 @@
 <launch>
   <include file="$(find motoman_sia50_support)/launch/load_sia50.launch" />
-  <param name="use_gui" value="true" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia50_support/package.xml
+++ b/motoman_sia50_support/package.xml
@@ -44,7 +44,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/motoman_sia5d_support/launch/test_sia5d.launch
+++ b/motoman_sia5d_support/launch/test_sia5d.launch
@@ -1,8 +1,6 @@
-
 <launch>
 	<include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia5d_support/package.xml
+++ b/motoman_sia5d_support/package.xml
@@ -41,7 +41,7 @@
 
   <test_depend>roslaunch</test_depend>
 
-  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>motoman_driver</exec_depend>
   <exec_depend>motoman_resources</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
Changed the test_<model>.launch files to use the "joint_state_publisher_gui" instead of the "joint_state_publisher" so that the joint slide controls are displayed with RViz.