### PR TITLE
gp35l: correct `a2` OPW parameter

### DIFF
--- a/motoman_gp35l_support/config/opw_parameters_gp35l.yaml
+++ b/motoman_gp35l_support/config/opw_parameters_gp35l.yaml
@@ -10,7 +10,7 @@
 #
 opw_kinematics_geometric_parameters:
     a1:  0.145
-    a2:  0.210
+    a2:  -0.210
     b:   0.000
     c1:  0.540
     c2:  1.150


### PR DESCRIPTION
Port isys-vision/motoman@7fb280a9.
