### PR TITLE
driver: Fixes `JointTrajPtFullEx::init` method

### DIFF
--- a/motoman_driver/src/simple_message/joint_traj_pt_full_ex.cpp
+++ b/motoman_driver/src/simple_message/joint_traj_pt_full_ex.cpp
@@ -82,7 +82,7 @@ void JointTrajPtFullEx::init(industrial::shared_types::shared_int num_groups,
 {
   this->setNumGroups(num_groups);
   this->setSequence(sequence);
-  this->setMultiJointTrajPtData(joint_trajectory_points_);
+  this->setMultiJointTrajPtData(joint_trajectory_points);
 }
 
 void JointTrajPtFullEx::copyFrom(JointTrajPtFullEx &src)


### PR DESCRIPTION
`setMultiJointTrajPointData(...)` was being passed the class member, not the argument, so this call had no effect when adding traj points.

Workaround is to just call `setMultiJointTrajPointData(...)` outside of `init(...)`