### PR TITLE
ci: switch to 24.04 runner

### DIFF
--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   industrial_ci:
     name: ROS Noetic (${{ matrix.ros_repo }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
As per title.

The `20.04` runner is being deprecated, following the EOL of Focal.
