### PR TITLE
Remove `--inorder` argument to `xacro` everywhere

### DIFF
--- a/motoman_ar2010_support/launch/load_ar2010.launch
+++ b/motoman_ar2010_support/launch/load_ar2010.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_ar2010_support)/urdf/ar2010.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_ar2010_support)/urdf/ar2010.xacro'" />
 </launch>

--- a/motoman_gp110_support/launch/load_gp110.launch
+++ b/motoman_gp110_support/launch/load_gp110.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp110_support)/urdf/gp110.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp110_support)/urdf/gp110.xacro'" />
 </launch>

--- a/motoman_gp12_support/launch/load_gp12.launch
+++ b/motoman_gp12_support/launch/load_gp12.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
 </launch>

--- a/motoman_gp165r_support/launch/load_gp165r.launch
+++ b/motoman_gp165r_support/launch/load_gp165r.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp165r_support)/urdf/gp165r.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp165r_support)/urdf/gp165r.xacro'" />
 </launch>

--- a/motoman_gp165r_support/launch/load_gp165r_equipped.launch
+++ b/motoman_gp165r_support/launch/load_gp165r_equipped.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp165r_support)/urdf/gp165r_equipped.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp165r_support)/urdf/gp165r_equipped.xacro'" />
 </launch>

--- a/motoman_gp180_support/launch/load_gp180.launch
+++ b/motoman_gp180_support/launch/load_gp180.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp180_support)/urdf/gp180.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp180_support)/urdf/gp180.xacro'" />
 </launch>

--- a/motoman_gp180_support/launch/load_gp180_120.launch
+++ b/motoman_gp180_support/launch/load_gp180_120.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp180_support)/urdf/gp180_120.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp180_support)/urdf/gp180_120.xacro'" />
 </launch>

--- a/motoman_gp200r_support/launch/load_gp200r.launch
+++ b/motoman_gp200r_support/launch/load_gp200r.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp200r_support)/urdf/gp200r.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp200r_support)/urdf/gp200r.xacro'" />
 </launch>

--- a/motoman_gp20hl_support/launch/load_gp20hl.launch
+++ b/motoman_gp20hl_support/launch/load_gp20hl.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp20hl_support)/urdf/gp20hl.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp20hl_support)/urdf/gp20hl.xacro'" />
 </launch>

--- a/motoman_gp215_support/launch/load_gp215.launch
+++ b/motoman_gp215_support/launch/load_gp215.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp215_support)/urdf/gp215.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp215_support)/urdf/gp215.xacro'" />
 </launch>

--- a/motoman_gp225_support/launch/load_gp225.launch
+++ b/motoman_gp225_support/launch/load_gp225.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp225_support)/urdf/gp225.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp225_support)/urdf/gp225.xacro'" />
 </launch>

--- a/motoman_gp250_support/launch/load_gp250.launch
+++ b/motoman_gp250_support/launch/load_gp250.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp250_support)/urdf/gp250.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp250_support)/urdf/gp250.xacro'" />
 </launch>

--- a/motoman_gp25_support/launch/load_gp25.launch
+++ b/motoman_gp25_support/launch/load_gp25.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp25_support)/urdf/gp25.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp25_support)/urdf/gp25.xacro'" />
 </launch>

--- a/motoman_gp25_support/launch/load_gp25_12.launch
+++ b/motoman_gp25_support/launch/load_gp25_12.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp25_support)/urdf/gp25_12.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp25_support)/urdf/gp25_12.xacro'" />
 </launch>

--- a/motoman_gp35l_support/launch/load_gp35l.launch
+++ b/motoman_gp35l_support/launch/load_gp35l.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp35l_support)/urdf/gp35l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp35l_support)/urdf/gp35l.xacro'" />
 </launch>

--- a/motoman_gp4_support/launch/load_gp4.launch
+++ b/motoman_gp4_support/launch/load_gp4.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp4_support)/urdf/gp4.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp4_support)/urdf/gp4.xacro'" />
 </launch>

--- a/motoman_gp50_support/launch/load_gp50.launch
+++ b/motoman_gp50_support/launch/load_gp50.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp50_support)/urdf/gp50.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp50_support)/urdf/gp50.xacro'" />
 </launch>

--- a/motoman_gp70l_support/launch/load_gp70l.launch
+++ b/motoman_gp70l_support/launch/load_gp70l.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp70l_support)/urdf/gp70l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp70l_support)/urdf/gp70l.xacro'" />
 </launch>

--- a/motoman_gp7_support/launch/load_gp7.launch
+++ b/motoman_gp7_support/launch/load_gp7.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
 </launch>

--- a/motoman_gp88_support/launch/load_gp88.launch
+++ b/motoman_gp88_support/launch/load_gp88.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp88_support)/urdf/gp88.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp88_support)/urdf/gp88.xacro'" />
 </launch>

--- a/motoman_gp8_support/launch/load_gp8.launch
+++ b/motoman_gp8_support/launch/load_gp8.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
 </launch>

--- a/motoman_gp8l_support/launch/load_gp8l.launch
+++ b/motoman_gp8l_support/launch/load_gp8l.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_gp8l_support)/urdf/gp8l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp8l_support)/urdf/gp8l.xacro'" />
 </launch>

--- a/motoman_hc10_support/launch/load_hc10.launch
+++ b/motoman_hc10_support/launch/load_hc10.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc10_support)/urdf/hc10.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc10_support)/urdf/hc10.xacro'" />
 </launch>

--- a/motoman_hc10_support/launch/load_hc10dt.launch
+++ b/motoman_hc10_support/launch/load_hc10dt.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc10_support)/urdf/hc10dt.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc10_support)/urdf/hc10dt.xacro'" />
 </launch>

--- a/motoman_hc10_support/launch/load_hc10dt_b10.launch
+++ b/motoman_hc10_support/launch/load_hc10dt_b10.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc10_support)/urdf/hc10dt_b10.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc10_support)/urdf/hc10dt_b10.xacro'" />
 </launch>

--- a/motoman_hc10_support/launch/load_hc10dtp_b00.launch
+++ b/motoman_hc10_support/launch/load_hc10dtp_b00.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc10_support)/urdf/hc10dtp_b00.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc10_support)/urdf/hc10dtp_b00.xacro'" />
 </launch>

--- a/motoman_hc20_support/launch/load_hc20.launch
+++ b/motoman_hc20_support/launch/load_hc20.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc20_support)/urdf/hc20.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc20_support)/urdf/hc20.xacro'" />
 </launch>

--- a/motoman_hc20_support/launch/load_hc20dtp.launch
+++ b/motoman_hc20_support/launch/load_hc20dtp.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc20_support)/urdf/hc20dtp.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc20_support)/urdf/hc20dtp.xacro'" />
 </launch>

--- a/motoman_hc20_support/launch/load_hc30pl.launch
+++ b/motoman_hc20_support/launch/load_hc30pl.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_hc20_support)/urdf/hc30pl.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_hc20_support)/urdf/hc30pl.xacro'" />
 </launch>

--- a/motoman_ma2010_support/launch/load_ma2010.launch
+++ b/motoman_ma2010_support/launch/load_ma2010.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_ma2010_support)/urdf/ma2010.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_ma2010_support)/urdf/ma2010.xacro'" />
 </launch>

--- a/motoman_mh110_support/launch/load_mh110.launch
+++ b/motoman_mh110_support/launch/load_mh110.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh110_support)/urdf/mh110.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh110_support)/urdf/mh110.xacro'" />
 </launch>

--- a/motoman_mh12_support/launch/load_mh12.launch
+++ b/motoman_mh12_support/launch/load_mh12.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh12_support)/urdf/mh12.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh12_support)/urdf/mh12.xacro'" />
 </launch>

--- a/motoman_mh50_support/launch/load_mh50.launch
+++ b/motoman_mh50_support/launch/load_mh50.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
 </launch>

--- a/motoman_mh5_support/launch/load_mh5.launch
+++ b/motoman_mh5_support/launch/load_mh5.launch
@@ -1,4 +1,4 @@
 
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh5_support)/urdf/mh5.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh5_support)/urdf/mh5.xacro'" />
 </launch>

--- a/motoman_mh5_support/launch/load_mh5l.launch
+++ b/motoman_mh5_support/launch/load_mh5l.launch
@@ -1,4 +1,4 @@
 
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mh5_support)/urdf/mh5l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh5_support)/urdf/mh5l.xacro'" />
 </launch>

--- a/motoman_motomini_support/launch/load_motomini.launch
+++ b/motoman_motomini_support/launch/load_motomini.launch
@@ -1,4 +1,4 @@
 
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_motomini_support)/urdf/motomini.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_motomini_support)/urdf/motomini.xacro'" />
 </launch>

--- a/motoman_motopos_d500_support/launch/load_motopos_d500.launch
+++ b/motoman_motopos_d500_support/launch/load_motopos_d500.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_motopos_d500_support)/urdf/motopos_d500.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_motopos_d500_support)/urdf/motopos_d500.xacro'" />
 </launch>

--- a/motoman_motopos_mh1655_support/launch/load_motopos_mh1655.launch
+++ b/motoman_motopos_mh1655_support/launch/load_motopos_mh1655.launch
@@ -1,4 +1,4 @@
 
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_motopos_mh1655_support)/urdf/motopos_mh1655.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_motopos_mh1655_support)/urdf/motopos_mh1655.xacro'" />
 </launch>

--- a/motoman_mpx1950_support/launch/load_mpx1950.launch
+++ b/motoman_mpx1950_support/launch/load_mpx1950.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mpx1950_support)/urdf/mpx1950.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mpx1950_support)/urdf/mpx1950.xacro'" />
 </launch>

--- a/motoman_ms210_support/launch/load_ms210.launch
+++ b/motoman_ms210_support/launch/load_ms210.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_ms210_support)/urdf/ms210.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_ms210_support)/urdf/ms210.xacro'" />
 </launch>

--- a/motoman_sda10f_support/launch/load_sda10f.launch
+++ b/motoman_sda10f_support/launch/load_sda10f.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sda10f_support)/urdf/sda10f.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/urdf/sda10f.xacro'" />
 </launch>

--- a/motoman_sda10f_support/test/launch_test.xml
+++ b/motoman_sda10f_support/test/launch_test.xml
@@ -41,7 +41,7 @@
   
   
   <group ns="urdf_sda10f">
-	  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sda10f_support)/test/sda10f_test.xacro'" />
+	  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/test/sda10f_test.xacro'" />
   </group>
 
 

--- a/motoman_sia10d_support/launch/load_sia10d.launch
+++ b/motoman_sia10d_support/launch/load_sia10d.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia10d_support)/urdf/sia10d.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10d_support)/urdf/sia10d.xacro'" />
 </launch>

--- a/motoman_sia10f_support/launch/load_sia10f.launch
+++ b/motoman_sia10f_support/launch/load_sia10f.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia10f_support)/urdf/sia10f.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10f_support)/urdf/sia10f.xacro'" />
 </launch>

--- a/motoman_sia20d_support/launch/load_sia20d.launch
+++ b/motoman_sia20d_support/launch/load_sia20d.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia20d_support)/urdf/sia20d.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia20d_support)/urdf/sia20d.xacro'" />
 </launch>

--- a/motoman_sia30d_support/launch/load_sia30d.launch
+++ b/motoman_sia30d_support/launch/load_sia30d.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia30d_support)/urdf/sia30d.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia30d_support)/urdf/sia30d.xacro'" />
 </launch>

--- a/motoman_sia50_support/launch/load_sia50.launch
+++ b/motoman_sia50_support/launch/load_sia50.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia50_support)/urdf/sia50.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia50_support)/urdf/sia50.xacro'" />
 </launch>

--- a/motoman_sia5d_support/launch/load_sia5d.launch
+++ b/motoman_sia5d_support/launch/load_sia5d.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_sia5d_support)/urdf/sia5d.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia5d_support)/urdf/sia5d.xacro'" />
 </launch>

--- a/moveit/motoman_ma2010_moveit_config/.setup_assistant
+++ b/moveit/motoman_ma2010_moveit_config/.setup_assistant
@@ -2,7 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: motoman_ma2010_support
     relative_path: urdf/ma2010.xacro
-    xacro_args: "--inorder "
+    xacro_args: ""
   SRDF:
     relative_path: config/motoman_ma2010.srdf
   CONFIG:

--- a/moveit/motoman_ma2010_moveit_config/launch/planning_context.launch
+++ b/moveit/motoman_ma2010_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find motoman_ma2010_support)/urdf/ma2010.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro '$(find motoman_ma2010_support)/urdf/ma2010.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find motoman_ma2010_moveit_config)/config/motoman_ma2010.srdf" />

--- a/moveit/motoman_ms210_moveit_config/launch/planning_context.launch
+++ b/moveit/motoman_ms210_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder  '$(find motoman_ms210_support)/urdf/ms210.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find motoman_ms210_support)/urdf/ms210.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find motoman_ms210_moveit_config)/config/motoman_ms210.srdf" />

--- a/moveit/motoman_sda10f_moveit_config/launch/planning_context.launch
+++ b/moveit/motoman_sda10f_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find motoman_sda10f_support)/urdf/sda10f.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/urdf/sda10f.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find motoman_sda10f_moveit_config)/config/motoman_sda10f.srdf" />

--- a/moveit/motoman_sia20d_moveit_config/.setup_assistant
+++ b/moveit/motoman_sia20d_moveit_config/.setup_assistant
@@ -2,7 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: motoman_sia20d_support
     relative_path: urdf/sia20d.xacro
-    xacro_args: "--inorder "
+    xacro_args: ""
   SRDF:
     relative_path: config/motoman_sia20d.srdf
   CONFIG:

--- a/moveit/motoman_sia20d_moveit_config/launch/planning_context.launch
+++ b/moveit/motoman_sia20d_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find motoman_sia20d_support)/urdf/sia20d.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro '$(find motoman_sia20d_support)/urdf/sia20d.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find motoman_sia20d_moveit_config)/config/motoman_sia20d.srdf" />


### PR DESCRIPTION
As per title.

No functional changes, all `roslaunch` tests still pass.

I'll rebase on #635 after that's merged.
