### PR TITLE
Use `xacro.load_yaml(..)` instead of deprecated `load_yaml(..)`

### DIFF
--- a/motoman_es_support/urdf/es165_macro.xacro
+++ b/motoman_es_support/urdf/es165_macro.xacro
@@ -166,7 +166,7 @@
     <!-- end of link list -->
 
     <!-- joint list -->
-    <xacro:property name="velocities" value="${load_yaml(joint_velocities_file)}" />
+    <xacro:property name="velocities" value="${xacro.load_yaml(joint_velocities_file)}" />
 
     <joint name="${prefix}joint_1_s" type="revolute">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>

--- a/motoman_es_support/urdf/es200_120_macro.xacro
+++ b/motoman_es_support/urdf/es200_120_macro.xacro
@@ -164,7 +164,7 @@
     <!-- end of link list -->
 
     <!-- joint list -->
-    <xacro:property name="velocities" value="${load_yaml(joint_velocities_file)}" />
+    <xacro:property name="velocities" value="${xacro.load_yaml(joint_velocities_file)}" />
 
     <joint name="${prefix}joint_1_s" type="revolute">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>


### PR DESCRIPTION
As per title.

No functional changes.

I'll rebase after #635 and #636 are merged.
