### PR TITLE
Tabs to spaces in `.xacro`, `.launch` and `roslaunch` tests

### DIFF
--- a/motoman_ar2010_support/launch/robot_interface_streaming_ar2010.launch
+++ b/motoman_ar2010_support/launch/robot_interface_streaming_ar2010.launch
@@ -9,14 +9,14 @@
     robot_interface_streaming_ar2010.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
-	
+  <arg name="robot_ip" />
+  
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller"/>
 
-	<rosparam command="load" file="$(find motoman_ar2010_support)/config/joint_names_ar2010.yaml" />
+  <rosparam command="load" file="$(find motoman_ar2010_support)/config/joint_names_ar2010.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 </launch>

--- a/motoman_ar2010_support/test/launch_test_ar2010.xml
+++ b/motoman_ar2010_support/test/launch_test_ar2010.xml
@@ -1,30 +1,30 @@
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="yrc1000" value="yrc1000"/>
   
   <group ns="load_ar2010">
-	  <include file="$(find motoman_ar2010_support)/launch/load_ar2010.launch"/>
+    <include file="$(find motoman_ar2010_support)/launch/load_ar2010.launch"/>
   </group>
 
   <group ns="test_ar2010">
-	  <include file="$(find motoman_ar2010_support)/launch/test_ar2010.launch"/>
+    <include file="$(find motoman_ar2010_support)/launch/test_ar2010.launch"/>
   </group>
 
   <group ns="robot_interface_streaming_ar2010">
     <group ns="yrc1000" >
-	    <include file="$(find motoman_ar2010_support)/launch/robot_interface_streaming_ar2010.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_ar2010_support)/launch/robot_interface_streaming_ar2010.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg yrc1000)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_ar2010">
     <group ns="yrc1000" >
-	    <include file="$(find motoman_ar2010_support)/launch/robot_state_visualize_ar2010.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_ar2010_support)/launch/robot_state_visualize_ar2010.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg yrc1000)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_driver/launch/robot_interface_streaming.launch
+++ b/motoman_driver/launch/robot_interface_streaming.launch
@@ -15,48 +15,48 @@
     robot_interface_streaming.launch robot_ip:=<value> use_bswap:=<true,false>
 -->
 
-	<!-- version0: Set to true for older/single arm joint trajectory action -->
-	<arg name="version0" doc="If true, driver assumes an older version of client without multi-group support" />
+  <!-- version0: Set to true for older/single arm joint trajectory action -->
+  <arg name="version0" doc="If true, driver assumes an older version of client without multi-group support" />
 
-	<!-- robot_ip: IP-address of the robot's socket-messaging server -->
-	<arg name="robot_ip" doc="IP of controller" />
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of controller" />
 
-	<!-- Load the byte-swapping versions of Fanuc nodes if required -->
-	<arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <!-- Load the byte-swapping versions of Fanuc nodes if required -->
+  <arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!-- copy the specified parameters to the Parameter Server, for 
-	     use by nodes below -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <!-- copy the specified parameters to the Parameter Server, for 
+       use by nodes below -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-	<!-- robot_state: publishes joint positions and robot-state data
-	     (from socket connection to robot)
-	-->
-	<include file="$(find motoman_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <!-- robot_state: publishes joint positions and robot-state data
+       (from socket connection to robot)
+  -->
+  <include file="$(find motoman_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<!-- motion_streaming_interface: sends robot motion commands by 
-	     STREAMING path to robot (using socket connection to robot) 
-	-->
-	<include file="$(find motoman_driver)/launch/motion_streaming_interface.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <!-- motion_streaming_interface: sends robot motion commands by 
+       STREAMING path to robot (using socket connection to robot) 
+  -->
+  <include file="$(find motoman_driver)/launch/motion_streaming_interface.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<!-- io_relay: sends and receives IO reads/writes to the controller
-	     (using socket connection to robot)
-	-->
-	<include file="$(find motoman_driver)/launch/io_relay.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <!-- io_relay: sends and receives IO reads/writes to the controller
+       (using socket connection to robot)
+  -->
+  <include file="$(find motoman_driver)/launch/io_relay.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<!-- joint_trajectory_action: provides actionlib interface for 
-	     high-level robot control
-	-->
-	<node if="$(arg version0)" name="joint_trajectory_action"
-		pkg="industrial_robot_client" type="joint_trajectory_action" />
-	<node unless="$(arg version0)" name="joint_trajectory_action"
-		pkg="motoman_driver" type="motoman_driver_joint_trajectory_action" />
+  <!-- joint_trajectory_action: provides actionlib interface for 
+       high-level robot control
+  -->
+  <node if="$(arg version0)" name="joint_trajectory_action"
+    pkg="industrial_robot_client" type="joint_trajectory_action" />
+  <node unless="$(arg version0)" name="joint_trajectory_action"
+    pkg="motoman_driver" type="motoman_driver_joint_trajectory_action" />
 </launch>

--- a/motoman_driver/launch/robot_interface_streaming_dx100.launch
+++ b/motoman_driver/launch/robot_interface_streaming_dx100.launch
@@ -6,15 +6,15 @@
     robot_interface_streaming_dx100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
-	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-		<arg name="version0"  value="$(arg version0)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+    <arg name="version0"  value="$(arg version0)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_interface_streaming_dx200.launch
+++ b/motoman_driver/launch/robot_interface_streaming_dx200.launch
@@ -6,15 +6,15 @@
     robot_interface_streaming_dx200.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
-	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-		<arg name="version0"  value="$(arg version0)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+    <arg name="version0"  value="$(arg version0)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_interface_streaming_fs100.launch
+++ b/motoman_driver/launch/robot_interface_streaming_fs100.launch
@@ -6,15 +6,15 @@
     robot_interface_streaming_fs100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
-	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-		<arg name="version0"  value="$(arg version0)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+    <arg name="version0"  value="$(arg version0)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
+++ b/motoman_driver/launch/robot_interface_streaming_yrc1000.launch
@@ -6,15 +6,15 @@
     robot_interface_streaming_yrc1000.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
-	<arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="version0" default="true" doc="If true, driver assumes an older version of client without multi-group support" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-		<arg name="version0"  value="$(arg version0)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+    <arg name="version0"  value="$(arg version0)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_dx100.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_dx100.launch
@@ -6,12 +6,12 @@
     robot_multigroup_interface_streaming_dx100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"  value="$(arg robot_ip)" />
-		<arg name="use_bswap" value="$(arg use_bswap)" />
-		<arg name="version0"  value="false" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"  value="$(arg robot_ip)" />
+    <arg name="use_bswap" value="$(arg use_bswap)" />
+    <arg name="version0"  value="false" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_dx200.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_dx200.launch
@@ -6,12 +6,12 @@
     robot_multigroup_interface_streaming_dx200.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"  value="$(arg robot_ip)" />
-		<arg name="use_bswap" value="$(arg use_bswap)" />
-		<arg name="version0"  value="false" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"  value="$(arg robot_ip)" />
+    <arg name="use_bswap" value="$(arg use_bswap)" />
+    <arg name="version0"  value="false" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_fs100.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_fs100.launch
@@ -6,14 +6,14 @@
     robot_multigroup_interface_streaming_fs100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"  value="$(arg robot_ip)" />
-		<arg name="use_bswap" value="$(arg use_bswap)" />
-		<arg name="version0"  value="false" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"  value="$(arg robot_ip)" />
+    <arg name="use_bswap" value="$(arg use_bswap)" />
+    <arg name="version0"  value="false" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_multigroup_interface_streaming_yrc1000.launch
+++ b/motoman_driver/launch/robot_multigroup_interface_streaming_yrc1000.launch
@@ -6,12 +6,12 @@
     robot_multigroup_interface_streaming_yrc1000.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" default="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"  value="$(arg robot_ip)" />
-		<arg name="use_bswap" value="$(arg use_bswap)" />
-		<arg name="version0"  value="false" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"  value="$(arg robot_ip)" />
+    <arg name="use_bswap" value="$(arg use_bswap)" />
+    <arg name="version0"  value="false" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_state.launch
+++ b/motoman_driver/launch/robot_state.launch
@@ -2,18 +2,18 @@
   Wrapper launch file for the Motoman specific robot_state node.
 -->
 <launch>
-	<!-- IP of robot (or PC running simulation) -->
-	<arg name="robot_ip" doc="IP of controller" />
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" doc="IP of controller" />
 
-	<!-- Load the byte-swapping version of robot_state if required -->
-	<arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <!-- Load the byte-swapping version of robot_state if required -->
+  <arg name="use_bswap" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!-- put them on the parameter server -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-	<!-- load the correct version of the robot state node -->
-	<node if="$(arg use_bswap)" name="joint_state" 
-		pkg="motoman_driver" type="robot_state_bswap" />
-	<node unless="$(arg use_bswap)" name="joint_state" 
-		pkg="motoman_driver" type="robot_state" />
+  <!-- load the correct version of the robot state node -->
+  <node if="$(arg use_bswap)" name="joint_state" 
+    pkg="motoman_driver" type="robot_state_bswap" />
+  <node unless="$(arg use_bswap)" name="joint_state" 
+    pkg="motoman_driver" type="robot_state" />
 </launch>

--- a/motoman_driver/launch/robot_state_dx100.launch
+++ b/motoman_driver/launch/robot_state_dx100.launch
@@ -6,13 +6,13 @@
     robot_state_dx100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_state_dx200.launch
+++ b/motoman_driver/launch/robot_state_dx200.launch
@@ -6,13 +6,13 @@
     robot_state_dx200.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_state_fs100.launch
+++ b/motoman_driver/launch/robot_state_fs100.launch
@@ -6,13 +6,13 @@
     robot_state_fs100.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" value="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" value="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/motoman_driver/launch/robot_state_yrc1000.launch
+++ b/motoman_driver/launch/robot_state_yrc1000.launch
@@ -6,13 +6,13 @@
     robot_state_yrc1000.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	<arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="use_bswap" value="false" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
-	<!--rosparam command="load" file="$(find motoman_config)/?" /-->
+  <!--rosparam command="load" file="$(find motoman_config)/?" /-->
 
-	<include file="$(find motoman_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/motoman_gp12_support/launch/load_gp12.launch
+++ b/motoman_gp12_support/launch/load_gp12.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp12_support)/urdf/gp12.xacro'" />
 </launch>

--- a/motoman_gp12_support/launch/robot_interface_streaming_gp12.launch
+++ b/motoman_gp12_support/launch/robot_interface_streaming_gp12.launch
@@ -9,14 +9,14 @@
     robot_interface_streaming_gp12.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
-	
+  <arg name="robot_ip" />
+  
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller"/>
 
-	<rosparam command="load" file="$(find motoman_gp12_support)/config/joint_names_gp12.yaml" />
+  <rosparam command="load" file="$(find motoman_gp12_support)/config/joint_names_gp12.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 </launch>

--- a/motoman_gp12_support/launch/robot_state_visualize_gp12.launch
+++ b/motoman_gp12_support/launch/robot_state_visualize_gp12.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_gp12.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
+  <arg name="robot_ip" />
 
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller" />
 
-	<rosparam command="load" file="$(find motoman_gp12_support)/config/joint_names_gp12.yaml" />
+  <rosparam command="load" file="$(find motoman_gp12_support)/config/joint_names_gp12.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_gp12_support)/launch/load_gp12.launch" />
+  <include file="$(find motoman_gp12_support)/launch/load_gp12.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp12_support/launch/test_gp12.launch
+++ b/motoman_gp12_support/launch/test_gp12.launch
@@ -1,7 +1,7 @@
 
 <launch>
-	<include file="$(find motoman_gp12_support)/launch/load_gp12.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_gp12_support)/launch/load_gp12.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp12_support/test/launch_test.xml
+++ b/motoman_gp12_support/test/launch_test.xml
@@ -27,32 +27,32 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="yrc1000" value="yrc1000"/>
   
   <group ns="load_gp12">
-	  <include file="$(find motoman_gp12_support)/launch/load_gp12.launch"/>
+    <include file="$(find motoman_gp12_support)/launch/load_gp12.launch"/>
   </group>
 
   <group ns="test_gp12">
-	  <include file="$(find motoman_gp12_support)/launch/test_gp12.launch"/>
+    <include file="$(find motoman_gp12_support)/launch/test_gp12.launch"/>
   </group>
 
   <group ns="robot_interface_streaming_gp12">
     <group ns="yrc1000" >
-	    <include file="$(find motoman_gp12_support)/launch/robot_interface_streaming_gp12.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_gp12_support)/launch/robot_interface_streaming_gp12.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg yrc1000)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_gp12">
     <group ns="yrc1000" >
-	    <include file="$(find motoman_gp12_support)/launch/robot_state_visualize_gp12.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_gp12_support)/launch/robot_state_visualize_gp12.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg yrc1000)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_gp12_support/urdf/gp12.xacro
+++ b/motoman_gp12_support/urdf/gp12.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_gp12" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_gp12_support)/urdf/gp12_macro.xacro" />
-	<xacro:motoman_gp12 prefix=""/>
+    <xacro:include filename="$(find motoman_gp12_support)/urdf/gp12_macro.xacro" />
+    <xacro:motoman_gp12 prefix=""/>
 </robot>
 
 

--- a/motoman_gp7_support/launch/load_gp7.launch
+++ b/motoman_gp7_support/launch/load_gp7.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp7_support)/urdf/gp7.xacro'" />
 </launch>

--- a/motoman_gp7_support/launch/robot_interface_streaming_gp7.launch
+++ b/motoman_gp7_support/launch/robot_interface_streaming_gp7.launch
@@ -9,14 +9,14 @@
     robot_interface_streaming_gp7.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
-	
+  <arg name="robot_ip" />
+  
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller"/>
 
-        <rosparam command="load" file="$(find motoman_gp7_support)/config/joint_names_gp7.yaml" />
+  <rosparam command="load" file="$(find motoman_gp7_support)/config/joint_names_gp7.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 </launch>

--- a/motoman_gp7_support/launch/robot_state_visualize_gp7.launch
+++ b/motoman_gp7_support/launch/robot_state_visualize_gp7.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_gp7.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
+  <arg name="robot_ip" />
 
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller" />
 
-        <rosparam command="load" file="$(find motoman_gp7_support)/config/joint_names_gp7.yaml" />
+  <rosparam command="load" file="$(find motoman_gp7_support)/config/joint_names_gp7.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_gp7_support)/launch/load_gp7.launch" />
+  <include file="$(find motoman_gp7_support)/launch/load_gp7.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp7_support/launch/test_gp7.launch
+++ b/motoman_gp7_support/launch/test_gp7.launch
@@ -1,7 +1,7 @@
 
 <launch>
-	<include file="$(find motoman_gp7_support)/launch/load_gp7.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_gp7_support)/launch/load_gp7.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp7_support/test/launch_test_gp7.xml
+++ b/motoman_gp7_support/test/launch_test_gp7.xml
@@ -27,32 +27,32 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="controller" value="yrc1000"/>
   
   <group ns="load_gp7">
-	  <include file="$(find motoman_gp7_support)/launch/load_gp7.launch"/>
+    <include file="$(find motoman_gp7_support)/launch/load_gp7.launch"/>
   </group>
 
   <group ns="test_gp7">
-	  <include file="$(find motoman_gp7_support)/launch/test_gp7.launch"/>
+    <include file="$(find motoman_gp7_support)/launch/test_gp7.launch"/>
   </group>
 
   <group ns="robot_interface_streaming_gp7">
     <group ns="$(arg controller)" >
-	    <include file="$(find motoman_gp7_support)/launch/robot_interface_streaming_gp7.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_gp7_support)/launch/robot_interface_streaming_gp7.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg controller)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_gp7">
     <group ns="$(arg controller)" >
-	    <include file="$(find motoman_gp7_support)/launch/robot_state_visualize_gp7.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_gp7_support)/launch/robot_state_visualize_gp7.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg controller)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_gp7_support/urdf/gp7.xacro
+++ b/motoman_gp7_support/urdf/gp7.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_gp7" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_gp7_support)/urdf/gp7_macro.xacro" />
-	<xacro:motoman_gp7 prefix=""/>
+    <xacro:include filename="$(find motoman_gp7_support)/urdf/gp7_macro.xacro" />
+    <xacro:motoman_gp7 prefix=""/>
 </robot>
 
 

--- a/motoman_gp8_support/launch/load_gp8.launch
+++ b/motoman_gp8_support/launch/load_gp8.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_gp8_support)/urdf/gp8.xacro'" />
 </launch>

--- a/motoman_gp8_support/launch/robot_interface_streaming_gp8.launch
+++ b/motoman_gp8_support/launch/robot_interface_streaming_gp8.launch
@@ -9,14 +9,14 @@
     robot_interface_streaming_gp8.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
-	
+  <arg name="robot_ip" />
+  
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller"/>
 
-        <rosparam command="load" file="$(find motoman_gp8_support)/config/joint_names_gp8.yaml" />
+  <rosparam command="load" file="$(find motoman_gp8_support)/config/joint_names_gp8.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 </launch>

--- a/motoman_gp8_support/launch/robot_state_visualize_gp8.launch
+++ b/motoman_gp8_support/launch/robot_state_visualize_gp8.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_gp8.launch robot_ip:=<value> controller:=<yrc1000>
 -->
 <launch>
-	<arg name="robot_ip" />
+  <arg name="robot_ip" />
 
   <!-- controller: Controller name (yrc1000) -->
   <arg name="controller" />
 
-        <rosparam command="load" file="$(find motoman_gp8_support)/config/joint_names_gp8.yaml" />
+  <rosparam command="load" file="$(find motoman_gp8_support)/config/joint_names_gp8.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_gp8_support)/launch/load_gp8.launch" />
+  <include file="$(find motoman_gp8_support)/launch/load_gp8.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp8_support/launch/test_gp8.launch
+++ b/motoman_gp8_support/launch/test_gp8.launch
@@ -1,7 +1,7 @@
 
 <launch>
-	<include file="$(find motoman_gp8_support)/launch/load_gp8.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_gp8_support)/launch/load_gp8.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_gp8_support/urdf/gp8.xacro
+++ b/motoman_gp8_support/urdf/gp8.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_gp8" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_gp8_support)/urdf/gp8_macro.xacro" />
-	<xacro:motoman_gp8 prefix=""/>
+    <xacro:include filename="$(find motoman_gp8_support)/urdf/gp8_macro.xacro" />
+    <xacro:motoman_gp8 prefix=""/>
 </robot>
 
 

--- a/motoman_gp8l_support/urdf/gp8l_macro.xacro
+++ b/motoman_gp8l_support/urdf/gp8l_macro.xacro
@@ -112,7 +112,7 @@
       <axis xyz="0 1 0" />
       <limit lower="${radians(-90)}" upper="${radians(155)}" effort="1029" velocity="${radians(230)}"/>
     </joint>
-	<joint name="${prefix}joint_3_u" type="revolute">
+    <joint name="${prefix}joint_3_u" type="revolute">
       <parent link="${prefix}link_2_l"/>
       <child link="${prefix}link_3_u"/>
       <origin xyz="0 0 0.714" rpy="0 0 0" />

--- a/motoman_mh50_support/launch/load_mh50.launch
+++ b/motoman_mh50_support/launch/load_mh50.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_mh50_support)/urdf/mh50.xacro'" />
 </launch>

--- a/motoman_mh50_support/launch/robot_interface_streaming_mh50.launch
+++ b/motoman_mh50_support/launch/robot_interface_streaming_mh50.launch
@@ -9,14 +9,14 @@
     robot_interface_streaming_mh50.launch robot_ip:=<value> controller:=<dx200>
 -->
 <launch>
-	<arg name="robot_ip" />
-	
+  <arg name="robot_ip" />
+  
   <!-- controller: Controller name (dx200) -->
   <arg name="controller"/>
 
-        <rosparam command="load" file="$(find motoman_mh50_support)/config/joint_names_mh50.yaml" />
+  <rosparam command="load" file="$(find motoman_mh50_support)/config/joint_names_mh50.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 </launch>

--- a/motoman_mh50_support/launch/robot_state_visualize_mh50.launch
+++ b/motoman_mh50_support/launch/robot_state_visualize_mh50.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_mh50.launch robot_ip:=<value> controller:=<dx200>
 -->
 <launch>
-	<arg name="robot_ip" />
+  <arg name="robot_ip" />
 
   <!-- controller: Controller name (dx200) -->
   <arg name="controller" />
 
-        <rosparam command="load" file="$(find motoman_mh50_support)/config/joint_names_mh50.yaml" />
+  <rosparam command="load" file="$(find motoman_mh50_support)/config/joint_names_mh50.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_mh50_support)/launch/load_mh50.launch" />
+  <include file="$(find motoman_mh50_support)/launch/load_mh50.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh50_support/launch/test_mh50.launch
+++ b/motoman_mh50_support/launch/test_mh50.launch
@@ -1,6 +1,6 @@
 <launch>
-	<include file="$(find motoman_mh50_support)/launch/load_mh50.launch" />
+  <include file="$(find motoman_mh50_support)/launch/load_mh50.launch" />
     <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_mh50_support/test/launch_test.xml
+++ b/motoman_mh50_support/test/launch_test.xml
@@ -27,32 +27,32 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx200" value="dx200"/>
   
   <group ns="load_mh50">
-	  <include file="$(find motoman_mh50_support)/launch/load_mh50.launch"/>
+    <include file="$(find motoman_mh50_support)/launch/load_mh50.launch"/>
   </group>
 
   <group ns="test_mh50">
-	  <include file="$(find motoman_mh50_support)/launch/test_mh50.launch"/>
+    <include file="$(find motoman_mh50_support)/launch/test_mh50.launch"/>
   </group>
 
   <group ns="robot_interface_streaming_mh50">
     <group ns="dx200" >
-	    <include file="$(find motoman_mh50_support)/launch/robot_interface_streaming_mh50.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_mh50_support)/launch/robot_interface_streaming_mh50.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx200)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_mh50">
     <group ns="dx200" >
-	    <include file="$(find motoman_mh50_support)/launch/robot_state_visualize_mh50.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_mh50_support)/launch/robot_state_visualize_mh50.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx200)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_mh50_support/urdf/mh50.xacro
+++ b/motoman_mh50_support/urdf/mh50.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_mh50" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_mh50_support)/urdf/mh50_macro.xacro" />
-	<xacro:motoman_mh50 prefix=""/>
+    <xacro:include filename="$(find motoman_mh50_support)/urdf/mh50_macro.xacro" />
+    <xacro:motoman_mh50 prefix=""/>
 </robot>
 
 

--- a/motoman_sda10f_support/launch/load_sda10f.launch
+++ b/motoman_sda10f_support/launch/load_sda10f.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/urdf/sda10f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/urdf/sda10f.xacro'" />
 </launch>

--- a/motoman_sda10f_support/launch/robot_interface_streaming_sda10f.launch
+++ b/motoman_sda10f_support/launch/robot_interface_streaming_sda10f.launch
@@ -10,7 +10,7 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of controller" />
-	
+  
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 
@@ -18,5 +18,5 @@
 
   <include file="$(find motoman_driver)/launch/robot_multigroup_interface_streaming_$(arg controller).launch">
     <arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  </include>
 </launch>

--- a/motoman_sda10f_support/launch/robot_state_visualize_sda10f.launch
+++ b/motoman_sda10f_support/launch/robot_state_visualize_sda10f.launch
@@ -9,7 +9,7 @@
     robot_state_visualize_sia20d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
@@ -17,14 +17,14 @@
   <rosparam command="load" file="$(find motoman_sda10f_support)/config/joint_names_sda10f.yaml" />
   <rosparam command="load" file="$(find motoman_sda10f_support)/config/sda10f_motion_interface.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch" />
+  <include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sda10f_support/launch/test_sda10f.launch
+++ b/motoman_sda10f_support/launch/test_sda10f.launch
@@ -1,7 +1,7 @@
 
 <launch>
-	<include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sda10f_support/test/launch_test.xml
+++ b/motoman_sda10f_support/test/launch_test.xml
@@ -27,53 +27,53 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx100" value="dx100"/>
   <arg name="fs100" value="fs100" />
 
   <group ns="load_sda10f">
-	  <include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch"/>
+    <include file="$(find motoman_sda10f_support)/launch/load_sda10f.launch"/>
   </group>
 
   <group ns="test_sda10f">
-	  <include file="$(find motoman_sda10f_support)/launch/test_sda10f.launch"/>
+    <include file="$(find motoman_sda10f_support)/launch/test_sda10f.launch"/>
   </group>
   
   
   <group ns="urdf_sda10f">
-	  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/test/sda10f_test.xacro'" />
+    <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sda10f_support)/test/sda10f_test.xacro'" />
   </group>
 
 
   <group ns="robot_interface_streaming_sda10f">
     <group ns="dx100" >
-	    <include file="$(find motoman_sda10f_support)/launch/robot_interface_streaming_sda10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sda10f_support)/launch/robot_interface_streaming_sda10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sda10f_support)/launch/robot_interface_streaming_sda10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sda10f_support)/launch/robot_interface_streaming_sda10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_sda10f">
     <group ns="dx100" >
-	    <include file="$(find motoman_sda10f_support)/launch/robot_state_visualize_sda10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sda10f_support)/launch/robot_state_visualize_sda10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sda10f_support)/launch/robot_state_visualize_sda10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sda10f_support)/launch/robot_state_visualize_sda10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_sda10f_support/urdf/sda10f.xacro
+++ b/motoman_sda10f_support/urdf/sda10f.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_sda10f" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sda10f_support)/urdf/sda10f_macro.xacro" />
-	<xacro:motoman_sda10f prefix=""/>
+    <xacro:include filename="$(find motoman_sda10f_support)/urdf/sda10f_macro.xacro" />
+    <xacro:motoman_sda10f prefix=""/>
 </robot>
 

--- a/motoman_sia10d_support/launch/load_sia10d.launch
+++ b/motoman_sia10d_support/launch/load_sia10d.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10d_support)/urdf/sia10d.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10d_support)/urdf/sia10d.xacro'" />
 </launch>

--- a/motoman_sia10d_support/launch/robot_interface_streaming_sia10d.launch
+++ b/motoman_sia10d_support/launch/robot_interface_streaming_sia10d.launch
@@ -9,8 +9,8 @@
     robot_interface_streaming_sia10d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
-	
+  <arg name="robot_ip" doc="IP of controller" />
+  
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 

--- a/motoman_sia10d_support/launch/robot_state_visualize_sia10d.launch
+++ b/motoman_sia10d_support/launch/robot_state_visualize_sia10d.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_sia20d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 
-	<rosparam command="load" file="$(find motoman_sia10d_support)/config/joint_names_sia10d.yaml" />
+  <rosparam command="load" file="$(find motoman_sia10d_support)/config/joint_names_sia10d.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch" />
+  <include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10d_support/launch/test_sia10d.launch
+++ b/motoman_sia10d_support/launch/test_sia10d.launch
@@ -1,7 +1,7 @@
 
 <launch>
-	<include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10d_support/test/launch_test.xml
+++ b/motoman_sia10d_support/test/launch_test.xml
@@ -27,48 +27,48 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx100" value="dx100"/>
   <arg name="fs100" value="fs100" />
 
   <group ns="load_sia10d">
-	  <include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch"/>
+    <include file="$(find motoman_sia10d_support)/launch/load_sia10d.launch"/>
   </group>
 
   <group ns="test_sia10d">
-	  <include file="$(find motoman_sia10d_support)/launch/test_sia10d.launch"/>
+    <include file="$(find motoman_sia10d_support)/launch/test_sia10d.launch"/>
   </group>
 
 
   <group ns="robot_interface_streaming_sia10d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia10d_support)/launch/robot_interface_streaming_sia10d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10d_support)/launch/robot_interface_streaming_sia10d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia10d_support)/launch/robot_interface_streaming_sia10d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10d_support)/launch/robot_interface_streaming_sia10d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_sia10d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia10d_support)/launch/robot_state_visualize_sia10d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10d_support)/launch/robot_state_visualize_sia10d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia10d_support)/launch/robot_state_visualize_sia10d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10d_support)/launch/robot_state_visualize_sia10d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_sia10d_support/urdf/sia10d.xacro
+++ b/motoman_sia10d_support/urdf/sia10d.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_sia10d" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sia10d_support)/urdf/sia10d_macro.xacro" />
-	<xacro:motoman_sia10d prefix=""/>
+    <xacro:include filename="$(find motoman_sia10d_support)/urdf/sia10d_macro.xacro" />
+    <xacro:motoman_sia10d prefix=""/>
 </robot>
 

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -1,292 +1,292 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:macro name="motoman_sia10d" params="prefix">
-		<xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
-		<!-- link list -->
-		<link name="world">
-    		<origin xyz="0 0 0" rpy="0 0 0"/>
-  		</link>
-		<link name="${prefix}base_link">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_BASE.stl" />
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_BASE.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="400" /> 	<!-- Arbitrarily large value, to simulate bolting down in case of absence of fixed joint -->
-      				<inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
-    			</inertial>
-		</link>
+    <xacro:macro name="motoman_sia10d" params="prefix">
+        <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
+        <!-- link list -->
+        <link name="world">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+        </link>
+        <link name="${prefix}base_link">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_BASE.stl" />
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_BASE.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="400" />  <!-- Arbitrarily large value, to simulate bolting down in case of absence of fixed joint -->
+                    <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}base_link">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/Blue</material>
-  		</gazebo>
+        <gazebo reference="${prefix}base_link">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/Blue</material>
+        </gazebo>
 
-		<link name="${prefix}link_s">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_S.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_silver/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_S.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="13.746057" />
-      				<inertia ixx="0.070027808" ixy="0.0" ixz="0.0" iyy="0.077808312" iyz="0.0" izz="0.043654657"/>
-				<origin xyz="0.0 0.0046451930 -0.018976267" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_s">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_S.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_silver/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_S.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="13.746057" />
+                    <inertia ixx="0.070027808" ixy="0.0" ixz="0.0" iyy="0.077808312" iyz="0.0" izz="0.043654657"/>
+                <origin xyz="0.0 0.0046451930 -0.018976267" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_s">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/White</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_s">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<link name="${prefix}link_l">
-			<visual>
-				<origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_L.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_L.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="5.227999" />
-      				<inertia ixx="0.016063413" ixy="0.0" ixz="0.0" iyy="0.10522920" iyz="0.0" izz="0.10250891"/>
-				<origin xyz="0.11422130 0.0 0.018935113" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_l">
+            <visual>
+                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_L.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_L.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="5.227999" />
+                    <inertia ixx="0.016063413" ixy="0.0" ixz="0.0" iyy="0.10522920" iyz="0.0" izz="0.10250891"/>
+                <origin xyz="0.11422130 0.0 0.018935113" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_l">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/Blue</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_l">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/Blue</material>
+        </gazebo>
 
-		<link name="${prefix}link_e">
-			<visual>
-				<origin rpy="0 0 3.1415" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_E.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_silver/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 3.1415" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_E.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="4.7092004" />
-      				<inertia ixx="0.030190273" ixy="0.0" ixz="0.0" iyy="0.030943336" iyz="0.0" izz="0.0096760191"/>
-				<origin xyz="0.0 -0.011901001 -0.036023969" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_e">
+            <visual>
+                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_E.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_silver/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_E.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="4.7092004" />
+                    <inertia ixx="0.030190273" ixy="0.0" ixz="0.0" iyy="0.030943336" iyz="0.0" izz="0.0096760191"/>
+                <origin xyz="0.0 -0.011901001 -0.036023969" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_e">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/White</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_e">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<link name="${prefix}link_u">
-			<visual>
-				<origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_U.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_U.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="3.1488649" />
-      				<inertia ixx="0.083840132" ixy="0.0" ixz="0.0" iyy="0.0061641860" iyz="0.0" izz="0.083291837"/>
-				<origin xyz="0.0 -0.015659426 0.13525753" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_u">
+            <visual>
+                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_U.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_U.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="3.1488649" />
+                    <inertia ixx="0.083840132" ixy="0.0" ixz="0.0" iyy="0.0061641860" iyz="0.0" izz="0.083291837"/>
+                <origin xyz="0.0 -0.015659426 0.13525753" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_u">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/Blue</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_u">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/Blue</material>
+        </gazebo>
 
-		<link name="${prefix}link_r">
-			<visual>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_R.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_silver/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_R.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="3.0270943" />
-      				<inertia ixx="0.017471059" ixy="0.0" ixz="0.0" iyy="0.017175292" iyz="0.0" izz="0.0049008824"/>
-				<origin xyz="0.0 -0.011271807 -0.0416" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
-		
-  		<gazebo reference="${prefix}link_r">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/White</material>
-  		</gazebo>
+        <link name="${prefix}link_r">
+            <visual>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_R.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_silver/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_R.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="3.0270943" />
+                    <inertia ixx="0.017471059" ixy="0.0" ixz="0.0" iyy="0.017175292" iyz="0.0" izz="0.0049008824"/>
+                <origin xyz="0.0 -0.011271807 -0.0416" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
+        
+        <gazebo reference="${prefix}link_r">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<link name="${prefix}link_b">
-			<visual>
-				<origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_B.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_B.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="2.3902999" />
-      				<inertia ixx="0.080" ixy="0.0" ixz="0.0" iyy="0.0038377449" iyz="0.0" izz="0.080"/>
-				<origin xyz="0.0 0.0074364051 0.078721289" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_b">
+            <visual>
+                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_B.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_B.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="2.3902999" />
+                    <inertia ixx="0.080" ixy="0.0" ixz="0.0" iyy="0.0038377449" iyz="0.0" izz="0.080"/>
+                <origin xyz="0.0 0.0074364051 0.078721289" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_b">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/Blue</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_b">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/Blue</material>
+        </gazebo>
 
-		<link name="${prefix}link_t">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_T.stl" />
-				</geometry>
-				<xacro:material_yaskawa_silver/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_T.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-			<inertial>
-      				<mass value="0.63670412" />
-      				<inertia ixx="0.00058471221" ixy="0.0" ixz="0.0" iyy="0.0005929671" iyz="0.0" izz="0.001081389"/>
-				<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
-    			</inertial>
-		</link>
+        <link name="${prefix}link_t">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/MOTOMAN_AXIS_T.stl" />
+                </geometry>
+                <xacro:material_yaskawa_silver/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/MOTOMAN_AXIS_T.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+            <inertial>
+                    <mass value="0.63670412" />
+                    <inertia ixx="0.00058471221" ixy="0.0" ixz="0.0" iyy="0.0005929671" iyz="0.0" izz="0.001081389"/>
+                <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+                </inertial>
+        </link>
 
-  		<gazebo reference="${prefix}link_t">
-    			<turnGravityOff>false</turnGravityOff>
-    			<selfCollide>true</selfCollide>
-			<material>Gazebo/White</material>
-  		</gazebo>
+        <gazebo reference="${prefix}link_t">
+                <turnGravityOff>false</turnGravityOff>
+                <selfCollide>true</selfCollide>
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<!-- end of link list -->
-		<!-- joint list -->
-	   	<joint name="world-base" type="fixed">
-   		 	<origin xyz="0 0 0" rpy="0 0 0"/>
-   		 	<parent link="world" />
-   		 	<child link="base_link"/>
-  		</joint>
-		<joint name="${prefix}joint_s" type="revolute">
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_s"/>
-			<origin xyz="0 0 0.36" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_l" type="revolute">
-			<parent link="${prefix}link_s"/>
-			<child link="${prefix}link_l"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_e" type="revolute">
-			<parent link="${prefix}link_l"/>
-			<child link="${prefix}link_e"/>
-			<origin xyz="0 0 0.36" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_u" type="revolute">
-			<parent link="${prefix}link_e"/>
-			<child link="${prefix}link_u"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-2.3561" upper="2.3561" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_r" type="revolute">
-			<parent link="${prefix}link_u"/>
-			<child link="${prefix}link_r"/>
-			<origin xyz="0 0 0.360" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_b" type="revolute">
-			<parent link="${prefix}link_r"/>
-			<child link="${prefix}link_b"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_t" type="revolute">
-			<parent link="${prefix}link_b"/>
-			<child link="${prefix}link_t"/>
-			<origin xyz="0 0 0.155" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
-		</joint>
-		<!-- end of joint list -->
+        <!-- end of link list -->
+        <!-- joint list -->
+        <joint name="world-base" type="fixed">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <parent link="world" />
+            <child link="base_link"/>
+        </joint>
+        <joint name="${prefix}joint_s" type="revolute">
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_s"/>
+            <origin xyz="0 0 0.36" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_l" type="revolute">
+            <parent link="${prefix}link_s"/>
+            <child link="${prefix}link_l"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_e" type="revolute">
+            <parent link="${prefix}link_l"/>
+            <child link="${prefix}link_e"/>
+            <origin xyz="0 0 0.36" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_u" type="revolute">
+            <parent link="${prefix}link_e"/>
+            <child link="${prefix}link_u"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-2.3561" upper="2.3561" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_r" type="revolute">
+            <parent link="${prefix}link_u"/>
+            <child link="${prefix}link_r"/>
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_b" type="revolute">
+            <parent link="${prefix}link_r"/>
+            <child link="${prefix}link_b"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_t" type="revolute">
+            <parent link="${prefix}link_b"/>
+            <child link="${prefix}link_t"/>
+            <origin xyz="0 0 0.155" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
+        </joint>
+        <!-- end of joint list -->
 
-		<!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.360" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/motoman_sia10f_support/launch/load_sia10f.launch
+++ b/motoman_sia10f_support/launch/load_sia10f.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10f_support)/urdf/sia10f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia10f_support)/urdf/sia10f.xacro'" />
 </launch>

--- a/motoman_sia10f_support/launch/robot_interface_streaming_sia10f.launch
+++ b/motoman_sia10f_support/launch/robot_interface_streaming_sia10f.launch
@@ -10,11 +10,11 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of controller" />
-	
+  
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 
-	<rosparam command="load" file="$(find motoman_sia10f_support)/config/joint_names_sia10f.yaml" />
+  <rosparam command="load" file="$(find motoman_sia10f_support)/config/joint_names_sia10f.yaml" />
 
   <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
     <arg name="robot_ip"   value="$(arg robot_ip)" />

--- a/motoman_sia10f_support/launch/robot_state_visualize_sia10f.launch
+++ b/motoman_sia10f_support/launch/robot_state_visualize_sia10f.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_sia20d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 
-	<rosparam command="load" file="$(find motoman_sia10f_support)/config/joint_names_sia10f.yaml" />
+  <rosparam command="load" file="$(find motoman_sia10f_support)/config/joint_names_sia10f.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch" />
+  <include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10f_support/launch/test_sia10f.launch
+++ b/motoman_sia10f_support/launch/test_sia10f.launch
@@ -1,6 +1,6 @@
 <launch>
-	<include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia10f_support/test/launch_test.xml
+++ b/motoman_sia10f_support/test/launch_test.xml
@@ -27,48 +27,48 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx100" value="dx100"/>
   <arg name="fs100" value="fs100" />
 
   <group ns="load_sia10f">
-	  <include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch"/>
+    <include file="$(find motoman_sia10f_support)/launch/load_sia10f.launch"/>
   </group>
 
   <group ns="test_sia10f">
-	  <include file="$(find motoman_sia10f_support)/launch/test_sia10f.launch"/>
+    <include file="$(find motoman_sia10f_support)/launch/test_sia10f.launch"/>
   </group>
 
 
   <group ns="robot_interface_streaming_sia10f">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia10f_support)/launch/robot_interface_streaming_sia10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10f_support)/launch/robot_interface_streaming_sia10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia10f_support)/launch/robot_interface_streaming_sia10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10f_support)/launch/robot_interface_streaming_sia10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_sia10f">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia10f_support)/launch/robot_state_visualize_sia10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10f_support)/launch/robot_state_visualize_sia10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia10f_support)/launch/robot_state_visualize_sia10f.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia10f_support)/launch/robot_state_visualize_sia10f.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_sia10f_support/urdf/sia10f.xacro
+++ b/motoman_sia10f_support/urdf/sia10f.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_sia10f" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sia10f_support)/urdf/sia10f_macro.xacro" />
-	<xacro:motoman_sia10f prefix=""/>
+    <xacro:include filename="$(find motoman_sia10f_support)/urdf/sia10f_macro.xacro" />
+    <xacro:motoman_sia10f prefix=""/>
 </robot>
 

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -1,198 +1,198 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:macro name="motoman_sia10f" params="prefix">
-		<xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
+    <xacro:macro name="motoman_sia10f" params="prefix">
+        <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
 
-		<!-- link list -->
-		<link name="${prefix}base_link">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_base.stl" />
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_base.stl" />
-				</geometry>
-				<material name="yellow">
-					<color rgba="0 1 1 1"/>
-				</material>
-			</collision>
-		</link>
-		<link name="${prefix}link_1_s">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_s.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_s.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_2_l">
-			<visual>
-				<origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_l.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_l.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_3_e">
-			<visual>
-				<origin rpy="0 0 3.1415" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_e.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 3.1415" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_e.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_4_u">
-			<visual>
-				<origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_u.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_u.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_5_r">
-			<visual>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_r.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_r.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_6_b">
-			<visual>
-				<origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_b.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_b.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_7_t">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_t.stl" />
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_t.stl" />
-				</geometry>
-				<material name="yellow"/>
-			</collision>
-		</link>
-		<link name="${prefix}link_tool0" />
-		<!-- end of link list -->
-		<!-- joint list -->
-		<joint name="${prefix}joint_1_s" type="revolute">
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_1_s"/>
-			<origin xyz="0 0 0.36" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_2_l" type="revolute">
-			<parent link="${prefix}link_1_s"/>
-			<child link="${prefix}link_2_l"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="0" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_3_e" type="revolute">
-			<parent link="${prefix}link_2_l"/>
-			<child link="${prefix}link_3_e"/>
-			<origin xyz="0 0 0.36" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-2.9670" upper="2.9670" effort="0" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_4_u" type="revolute">
-			<parent link="${prefix}link_3_e"/>
-			<child link="${prefix}link_4_u"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-2.3561" upper="2.3561" effort="0" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_5_r" type="revolute">
-			<parent link="${prefix}link_4_u"/>
-			<child link="${prefix}link_5_r"/>
-			<origin xyz="0 0 0.360" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_6_b" type="revolute">
-			<parent link="${prefix}link_5_r"/>
-			<child link="${prefix}link_6_b"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="0" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_7_t" type="revolute">
-			<parent link="${prefix}link_6_b"/>
-			<child link="${prefix}link_7_t"/>
-			<origin xyz="0 0 0.155" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.9813" />
-		</joint>
+        <!-- link list -->
+        <link name="${prefix}base_link">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_base.stl" />
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_base.stl" />
+                </geometry>
+                <material name="yellow">
+                    <color rgba="0 1 1 1"/>
+                </material>
+            </collision>
+        </link>
+        <link name="${prefix}link_1_s">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_s.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_s.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_2_l">
+            <visual>
+                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_l.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_l.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_3_e">
+            <visual>
+                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_e.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_e.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_4_u">
+            <visual>
+                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_u.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_u.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_5_r">
+            <visual>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_r.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_r.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_6_b">
+            <visual>
+                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_b.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_b.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_7_t">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/motoman_axis_t.stl" />
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/motoman_axis_t.stl" />
+                </geometry>
+                <material name="yellow"/>
+            </collision>
+        </link>
+        <link name="${prefix}link_tool0" />
+        <!-- end of link list -->
+        <!-- joint list -->
+        <joint name="${prefix}joint_1_s" type="revolute">
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1_s"/>
+            <origin xyz="0 0 0.36" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_2_l" type="revolute">
+            <parent link="${prefix}link_1_s"/>
+            <child link="${prefix}link_2_l"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="0" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_3_e" type="revolute">
+            <parent link="${prefix}link_2_l"/>
+            <child link="${prefix}link_3_e"/>
+            <origin xyz="0 0 0.36" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-2.9670" upper="2.9670" effort="0" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_4_u" type="revolute">
+            <parent link="${prefix}link_3_e"/>
+            <child link="${prefix}link_4_u"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-2.3561" upper="2.3561" effort="0" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_5_r" type="revolute">
+            <parent link="${prefix}link_4_u"/>
+            <child link="${prefix}link_5_r"/>
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_6_b" type="revolute">
+            <parent link="${prefix}link_5_r"/>
+            <child link="${prefix}link_6_b"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="0" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_7_t" type="revolute">
+            <parent link="${prefix}link_6_b"/>
+            <child link="${prefix}link_7_t"/>
+            <origin xyz="0 0 0.155" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.9813" />
+        </joint>
     <joint name="${prefix}joint_tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1415926535"/>
       <parent link="${prefix}link_7_t" />
       <child link="${prefix}link_tool0" />
     </joint>
-		<!-- end of joint list -->
+        <!-- end of joint list -->
 
-		<!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.360" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/motoman_sia20d_support/launch/load_sia20d.launch
+++ b/motoman_sia20d_support/launch/load_sia20d.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia20d_support)/urdf/sia20d.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia20d_support)/urdf/sia20d.xacro'" />
 </launch>

--- a/motoman_sia20d_support/launch/robot_interface_streaming_sia20d.launch
+++ b/motoman_sia20d_support/launch/robot_interface_streaming_sia20d.launch
@@ -9,7 +9,7 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of controller" />
-	
+  
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 

--- a/motoman_sia20d_support/launch/robot_state_visualize_sia20d.launch
+++ b/motoman_sia20d_support/launch/robot_state_visualize_sia20d.launch
@@ -8,21 +8,21 @@
     robot_state_visualize_sia20d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 
-	<rosparam command="load" file="$(find motoman_sia20d_support)/config/joint_names_sia20d.yaml" />
+  <rosparam command="load" file="$(find motoman_sia20d_support)/config/joint_names_sia20d.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch" />
+  <include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia20d_support/launch/test_sia20d.launch
+++ b/motoman_sia20d_support/launch/test_sia20d.launch
@@ -1,6 +1,6 @@
 <launch>
-	<include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch" />
+  <include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch" />
     <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia20d_support/test/launch_test.xml
+++ b/motoman_sia20d_support/test/launch_test.xml
@@ -26,48 +26,48 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx100" value="dx100"/>
   <arg name="fs100" value="fs100" />
 
   <group ns="load_sia20d">
-	  <include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch"/>
+    <include file="$(find motoman_sia20d_support)/launch/load_sia20d.launch"/>
   </group>
 
   <group ns="test_sia20d">
-	  <include file="$(find motoman_sia20d_support)/launch/test_sia20d.launch"/>
+    <include file="$(find motoman_sia20d_support)/launch/test_sia20d.launch"/>
   </group>
 
 
   <group ns="robot_interface_streaming_sia20d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia20d_support)/launch/robot_interface_streaming_sia20d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia20d_support)/launch/robot_interface_streaming_sia20d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia20d_support)/launch/robot_interface_streaming_sia20d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia20d_support)/launch/robot_interface_streaming_sia20d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_sia20d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia20d_support)/launch/robot_state_visualize_sia20d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia20d_support)/launch/robot_state_visualize_sia20d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia20d_support)/launch/robot_state_visualize_sia20d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia20d_support)/launch/robot_state_visualize_sia20d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_sia20d_support/urdf/sia20d.xacro
+++ b/motoman_sia20d_support/urdf/sia20d.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="motoman_sia20d" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sia20d_support)/urdf/sia20d_macro.xacro" />
-	<xacro:motoman_sia20d prefix=""/>
+    <xacro:include filename="$(find motoman_sia20d_support)/urdf/sia20d_macro.xacro" />
+    <xacro:motoman_sia20d prefix=""/>
 </robot>
 

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -1,198 +1,198 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:macro name="motoman_sia20d" params="prefix">
-		<xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
+    <xacro:macro name="motoman_sia20d" params="prefix">
+        <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
 
-		<!-- link list -->
-		<link name="${prefix}base_link">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_BASE.stl" />
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_BASE.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_s">
-			<visual>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_S.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_S.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_l">
-			<visual>
-				<origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_L.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_L.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_e">
-			<visual>
-				<origin rpy="0 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_E.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_E.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_u">
-			<visual>
-				<origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_U.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_U.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_r">
-			<visual>
-				<origin rpy="0 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_R.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<origin rpy="0 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_R.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_b">
-			<visual>
-				<origin rpy="-1.57 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_B.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_blue/>
-			</visual>
-			<collision>
-				<origin rpy="-1.57 0 0" xyz="0 0 0"/>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_B.stl"/>
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
-		<link name="${prefix}link_t">
-			<visual>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_T.stl" />
-				</geometry>
-				<xacro:material_yaskawa_white/>
-			</visual>
-			<collision>
-				<geometry>
-					<mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_T.stl" />
-				</geometry>
-				<xacro:material_yaskawa_yellow/>
-			</collision>
-		</link>
+        <!-- link list -->
+        <link name="${prefix}base_link">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_BASE.stl" />
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_BASE.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_s">
+            <visual>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_S.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_S.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_l">
+            <visual>
+                <origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_L.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_L.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_e">
+            <visual>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_E.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_E.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_u">
+            <visual>
+                <origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_U.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_U.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_r">
+            <visual>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_R.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_R.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_b">
+            <visual>
+                <origin rpy="-1.57 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_B.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_blue/>
+            </visual>
+            <collision>
+                <origin rpy="-1.57 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_B.stl"/>
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
+        <link name="${prefix}link_t">
+            <visual>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/MOTOMAN_AXIS_T.stl" />
+                </geometry>
+                <xacro:material_yaskawa_white/>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/MOTOMAN_AXIS_T.stl" />
+                </geometry>
+                <xacro:material_yaskawa_yellow/>
+            </collision>
+        </link>
     <link name="${prefix}tool0" />
-		<!-- end of link list -->
-		<!-- joint list -->
-		<joint name="${prefix}joint_s" type="revolute">
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_s"/>
-			<origin xyz="0 0 0.41" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.2689" />
-		</joint>
-		<joint name="${prefix}joint_l" type="revolute">
-			<parent link="${prefix}link_s"/>
-			<child link="${prefix}link_l"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.2689" />
-		</joint>
-		<joint name="${prefix}joint_e" type="revolute">
-			<parent link="${prefix}link_l"/>
-			<child link="${prefix}link_e"/>
-			<origin xyz="0 0 0.49" rpy="0 0 0"/>
-			<axis xyz="0 0 1" />
-			<limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_u" type="revolute">
-			<parent link="${prefix}link_e"/>
-			<child link="${prefix}link_u"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-2.2689" upper="2.2689" effort="100" velocity="2.9670" />
-		</joint>
-		<joint name="${prefix}joint_r" type="revolute">
-			<parent link="${prefix}link_u"/>
-			<child link="${prefix}link_r"/>
-			<origin xyz="0 0 0.420" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_b" type="revolute">
-			<parent link="${prefix}link_r"/>
-			<child link="${prefix}link_b"/>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<axis xyz="0 -1 0" />
-			<limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
-		</joint>
-		<joint name="${prefix}joint_t" type="revolute">
-			<parent link="${prefix}link_b"/>
-			<child link="${prefix}link_t"/>
-			<origin xyz="0 0 0.18" rpy="0 0 0"/>
-			<axis xyz="0 0 -1" />
-			<limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
-		</joint>
+        <!-- end of link list -->
+        <!-- joint list -->
+        <joint name="${prefix}joint_s" type="revolute">
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_s"/>
+            <origin xyz="0 0 0.41" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.2689" />
+        </joint>
+        <joint name="${prefix}joint_l" type="revolute">
+            <parent link="${prefix}link_s"/>
+            <child link="${prefix}link_l"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.2689" />
+        </joint>
+        <joint name="${prefix}joint_e" type="revolute">
+            <parent link="${prefix}link_l"/>
+            <child link="${prefix}link_e"/>
+            <origin xyz="0 0 0.49" rpy="0 0 0"/>
+            <axis xyz="0 0 1" />
+            <limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_u" type="revolute">
+            <parent link="${prefix}link_e"/>
+            <child link="${prefix}link_u"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-2.2689" upper="2.2689" effort="100" velocity="2.9670" />
+        </joint>
+        <joint name="${prefix}joint_r" type="revolute">
+            <parent link="${prefix}link_u"/>
+            <child link="${prefix}link_r"/>
+            <origin xyz="0 0 0.420" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_b" type="revolute">
+            <parent link="${prefix}link_r"/>
+            <child link="${prefix}link_b"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <axis xyz="0 -1 0" />
+            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
+        </joint>
+        <joint name="${prefix}joint_t" type="revolute">
+            <parent link="${prefix}link_b"/>
+            <child link="${prefix}link_t"/>
+            <origin xyz="0 0 0.18" rpy="0 0 0"/>
+            <axis xyz="0 0 -1" />
+            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
+        </joint>
     <joint name="${prefix}link_t-tool0" type="fixed" >
       <origin xyz="0 0 0.0" rpy="0 0 -3.1415926535"/>
       <parent link="${prefix}link_t" />
       <child link="${prefix}tool0" />
     </joint>
-		<!-- end of joint list -->
+        <!-- end of joint list -->
 
-		<!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.410" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.410" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/motoman_sia5d_support/launch/load_sia5d.launch
+++ b/motoman_sia5d_support/launch/load_sia5d.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia5d_support)/urdf/sia5d.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find motoman_sia5d_support)/urdf/sia5d.xacro'" />
 </launch>

--- a/motoman_sia5d_support/launch/robot_interface_streaming_sia5d.launch
+++ b/motoman_sia5d_support/launch/robot_interface_streaming_sia5d.launch
@@ -10,7 +10,7 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of controller" />
-	
+  
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
 

--- a/motoman_sia5d_support/launch/robot_state_visualize_sia5d.launch
+++ b/motoman_sia5d_support/launch/robot_state_visualize_sia5d.launch
@@ -9,21 +9,21 @@
     robot_state_visualize_sia20d.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
-	<arg name="robot_ip" doc="IP of controller" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- controller: Controller name (fs100 or dx100) -->
   <arg name="controller" doc="Series of the controller (dx100, dx200, fs100 or yrc1000)"/>
 
-	<rosparam command="load" file="$(find motoman_sia5d_support)/config/joint_names_sia5d.yaml" />
+  <rosparam command="load" file="$(find motoman_sia5d_support)/config/joint_names_sia5d.yaml" />
 
-	<include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-	</include>
+  <include file="$(find motoman_driver)/launch/robot_state_$(arg controller).launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch" />
+  <include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia5d_support/launch/test_sia5d.launch
+++ b/motoman_sia5d_support/launch/test_sia5d.launch
@@ -1,6 +1,6 @@
 <launch>
-	<include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch" />
-	<node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/motoman_sia5d_support/test/launch_test.xml
+++ b/motoman_sia5d_support/test/launch_test.xml
@@ -27,48 +27,48 @@
   testing multpile launch files
 -->
 <launch>
-	<arg name="req_arg" value="default"/>
+  <arg name="req_arg" value="default"/>
   <arg name="dx100" value="dx100"/>
   <arg name="fs100" value="fs100" />
 
   <group ns="load_sia5d">
-	  <include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch"/>
+    <include file="$(find motoman_sia5d_support)/launch/load_sia5d.launch"/>
   </group>
 
   <group ns="test_sia5d">
-	  <include file="$(find motoman_sia5d_support)/launch/test_sia5d.launch"/>
+    <include file="$(find motoman_sia5d_support)/launch/test_sia5d.launch"/>
   </group>
 
 
   <group ns="robot_interface_streaming_sia5d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia5d_support)/launch/robot_interface_streaming_sia5d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia5d_support)/launch/robot_interface_streaming_sia5d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia5d_support)/launch/robot_interface_streaming_sia5d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia5d_support)/launch/robot_interface_streaming_sia5d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 
   <group ns="robot_state_visualize_sia5d">
     <group ns="dx100" >
-	    <include file="$(find motoman_sia5d_support)/launch/robot_state_visualize_sia5d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia5d_support)/launch/robot_state_visualize_sia5d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg dx100)"/>
-	    </include>
+      </include>
     </group>
 
     <group ns="fs100" >
-	    <include file="$(find motoman_sia5d_support)/launch/robot_state_visualize_sia5d.launch">
-		    <arg name="robot_ip"   value="$(arg req_arg)" />
+      <include file="$(find motoman_sia5d_support)/launch/robot_state_visualize_sia5d.launch">
+        <arg name="robot_ip"   value="$(arg req_arg)" />
         <arg name="controller" value="$(arg fs100)"/>
-	    </include>
+      </include>
     </group>
   </group>
 

--- a/motoman_sia5d_support/urdf/sia5d.xacro
+++ b/motoman_sia5d_support/urdf/sia5d.xacro
@@ -3,7 +3,7 @@
 <!--Generates a urdf from the macro in sia5_macro.xacro -->
 
 <robot name="motoman_sia5d" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find motoman_sia5d_support)/urdf/sia5d_macro.xacro"/>
-	<xacro:motoman_sia5d prefix=""/>
+    <xacro:include filename="$(find motoman_sia5d_support)/urdf/sia5d_macro.xacro"/>
+    <xacro:motoman_sia5d prefix=""/>
 </robot>
 

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<xacro:property name="deg" value="0.017453293" /> <!--degrees to radians-->
-	
-	<xacro:macro name="motoman_sia5d" params="prefix">
+    <xacro:property name="deg" value="0.017453293" /> <!--degrees to radians-->
+    
+    <xacro:macro name="motoman_sia5d" params="prefix">
 
   <xacro:include filename="$(find motoman_resources)/urdf/common_materials.xacro"/>
 
@@ -198,6 +198,6 @@
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
     </joint>
-	</xacro:macro>
+    </xacro:macro>
 </robot>
 


### PR DESCRIPTION
As per title.

No functional changes.

We had a mix of spaces and/or tabs used for indentation in these files, which was really annoying, especially since we also have mixed 2 and 4 space indents.

Used separate commits to make reviewing slightly more convenient (easier to compare similar changes to similar files).
